### PR TITLE
Fix dates returned by detailed_measures_resp2py on DST

### DIFF
--- a/lowatt_enedis/__init__.py
+++ b/lowatt_enedis/__init__.py
@@ -42,6 +42,7 @@ logging.basicConfig(level=logging.INFO)
 # logging.getLogger('suds.mx').setLevel(logging.DEBUG)
 # logging.getLogger('suds.transport').setLevel(logging.DEBUG)
 
+LOGGER = logging.getLogger(__name__)
 
 WSDL_DIR = PurePath(__file__).parent.joinpath("wsdl")
 SERVICES = {x.stem: x.resolve().as_uri() for x in Path(WSDL_DIR).glob("**/*.wsdl")}

--- a/lowatt_enedis/services.py
+++ b/lowatt_enedis/services.py
@@ -25,7 +25,7 @@ from datetime import date, timedelta
 
 from dateutil import tz
 
-from . import create_from_options, dict_from_dicts, get_option, register, ws
+from . import LOGGER, create_from_options, dict_from_dicts, get_option, register, ws
 
 UTC = tz.tzutc()
 ACCORD_CLIENT_OPTIONS = {
@@ -417,12 +417,21 @@ def point_detailed_measures(client, args):
 def detailed_measures_resp2py(resp):
     """Return an iterator on (UTC tz naive datetime, value) given a response from
     ConsultationMesuresDetaillees web-service.
+
+    Also fix repetition of timestamp due to wrong tz offset returned by Enedis :/
     """
     # start = resp.periode.dateDebut
     # end = resp.periode.dateFin
     assert len(resp.grandeur) == 1
+    dst_end_set = set()
     for point in resp.grandeur[0].mesure:
-        yield (point.d.astimezone(UTC), point.v)
+        dt = point.d.astimezone(UTC)
+        if dt.month == 10:
+            if dt in dst_end_set:
+                LOGGER.info("Automatically fix DST end date %s", dt)
+                dt = dt + timedelta(seconds=60 * 60)
+            dst_end_set.add(dt)
+        yield (dt, point.v)
 
 
 @register(


### PR DESCRIPTION
This applies only on COURBE data where we have point for each 10
minutes.

In this case enedis response return twice the same date range during
DST, the first hour has obviously a wrong tz offset.

Handle this by detailed_measures_resp2py() and add missing hour so we
don't generate duplicate UTC dates.