### PR TITLE
Fix cmdInfraJ accord soutirage and injection

### DIFF
--- a/doc/homologation.md
+++ b/doc/homologation.md
@@ -76,7 +76,7 @@ CommandeTransmissionDonneesInfraJ v1.0
 
 | Case      | Command                                                                                                              |
 |-----------|----------------------------------------------------------------------------------------------------------------------|
-| F375A-R1  | *XFAIL* `lowatt-enedis cmdInfraJ 98800000000246 --cdc --injection --denomination "Raison Sociale"`                   |
+| F375A-R1  | *XFAIL* `lowatt-enedis cmdInfraJ 98800000000246 --cdc --soutirage --denomination "Raison Sociale"`                   |
 | F375A-NR1 | *XFAIL* `lowatt-enedis cmdInfraJ 98800000000246 --idx --injection --denomination "Raison Sociale" --no-autorisation` |
 
 

--- a/lowatt_enedis/services.py
+++ b/lowatt_enedis/services.py
@@ -612,8 +612,8 @@ def point_cmd_infra_j(client, args):
         xs_accord_type="ns1:DeclarationAccordClientType",
         autorisation=not get_option(args, "no_autorisation"),
     )
-    accord.injection = _boolean(False)
-    accord.soutirage = _boolean(False)
+    accord.injection = _boolean(get_option(args, "injection"))
+    accord.soutirage = _boolean(get_option(args, "soutirage"))
     return client.service.commanderTransmissionDonneesInfraJ(demande)
 
 


### PR DESCRIPTION
Set accord.injection and accord.soutirage accordingly with --injection
and --soutirage.

F375A-R1 ask for accord.soutirage to be True.
It's not clear about F375A-NR1 if we need "--soutirage --no-autorisation" or "--injection" or "--injection --no-autorisation".

From documentation "L’autorisation du client par soutirage n’est pas confirmée." so I guess at least accord.soutirage must be False.