### PR TITLE
Update homologation instructions for SGE Tiers v23.1

### DIFF
--- a/doc/homologation.md
+++ b/doc/homologation.md
@@ -50,6 +50,10 @@ ConsultationMesures v1.1
 ConsultationMesuresDetaillees v2.0
 ----------------------------------
 
+**The decommissioning of this version is planned for the end of 2023.**
+
+> La version 2 du webservice ConsultationMesureDetaillees sera décomissionné fin 2023.
+
 | Case            | Command                                                                                           |
 |-----------------|---------------------------------------------------------------------------------------------------|
 | CMD2-R1 (C1-C4) | `lowatt-enedis details 30001610071843 COURBE --from 2022-04-01 --to 2022-04-07`                   |

--- a/doc/homologation.md
+++ b/doc/homologation.md
@@ -3,8 +3,8 @@ Homologation
 
 This explain how to pass through Enedis homologation process.
 
-This is based on SGE v22.1 (from `Enedis.SGE.REF.0465.Homologation_Catalogue
-des cas de tests_Tiers_SGE22.1_v1.0.pdf`) cases.
+This is based on SGE v23.1 (from `Enedis.SGE.REF.0465.Homologation_Catalogue 
+des cas de tests_Tiers_SGE23.1_v1.0.pdf`) cases.
 
 First setup `lowatt-enedis` and then execute given commands for each services
 you want homologation and report the time the command was run to fill Enedis
@@ -25,13 +25,15 @@ $ export ENEDIS_HOMOLOGATION=on
 ```
 
 
-ConsultationDonneesTechniquesContractuelles v0
-----------------------------------------------
+ConsultationDonneesTechniquesContractuelles v1.0
+------------------------------------------------
 
 | Case           | Command                                                 |
 |----------------|---------------------------------------------------------|
 | ADP-R1 (C1-C4) | `lowatt-enedis technical --autorisation 98800007059999` |
 | ADP-R1 (C5)    | `lowatt-enedis technical --autorisation 25946599093143` |
+| ADP-R2 (C1-C4) | `lowatt-enedis technical 98800007059999`                |
+| ADP-R2 (C5)    | `lowatt-enedis technical 25946599093143`                |
 | ADP-NR1        | `lowatt-enedis technical 99999999999999`                |
 
 
@@ -50,13 +52,28 @@ ConsultationMesuresDetaillees v2.0
 
 | Case            | Command                                                                                           |
 |-----------------|---------------------------------------------------------------------------------------------------|
-| CMD2-R1 (C1-C4) | `lowatt-enedis details 30001610071843 COURBE --from 2020-03-01 --to 2020-03-08`                   |
-| CMD2-R1 (C5)    | `lowatt-enedis details 25478147557460 COURBE --from 2020-03-01 --to 2020-03-08`                   |
-| CMD2-R2         | `lowatt-enedis details 30001610071843 COURBE --courbe-type PRI --from 2020-03-01 --to 2020-03-08` |
-| CMD2-R3         | `lowatt-enedis details 25478147557460 ENERGIE --from 2020-03-01 --to 2020-03-08`                  |
-| CMD2-R4         | `lowatt-enedis details 25478147557460 PMAX --from 2020-03-01 --to 2020-03-08`                     |
-| CMD2-NR1        | `lowatt-enedis details 25478147557460 COURBE --from 2020-03-01 --to 2020-03-10`                   |
-| CMD2-NR2        | `lowatt-enedis details 25478147557460 ENERGIE --from 2020-03-01 --to 2020-03-08 --no-autorisation`|
+| CMD2-R1 (C1-C4) | `lowatt-enedis details 30001610071843 COURBE --from 2022-04-01 --to 2022-04-07`                   |
+| CMD2-R1 (C5)    | `lowatt-enedis details 25478147557460 COURBE --from 2022-04-01 --to 2022-04-07`                   |
+| CMD2-R2         | `lowatt-enedis details 30001610071843 COURBE --courbe-type PRI --from 2022-04-01 --to 2022-04-07` |
+| CMD2-R3         | `lowatt-enedis details 25478147557460 ENERGIE --from 2022-04-01 --to 2022-04-07`                  |
+| CMD2-R4         | `lowatt-enedis details 25478147557460 PMAX --from 2022-04-01 --to 2022-04-07`                     |
+| CMD2-NR1        | `lowatt-enedis details 25478147557460 COURBE --from 2022-04-01 --to 2022-04-07`                   |
+| CMD2-NR2        | `lowatt-enedis details 25478147557460 ENERGIE --from 2022-04-01 --to 2022-04-07 --no-autorisation`|
+
+
+ConsultationMesuresDetaillees v3.0
+----------------------------------
+
+| Case      | Command                 |
+|-----------|-------------------------|
+| CMD3-R1   | *Not implemented yet.*  |
+| CMD3-R2   | *Not implemented yet.*  |
+| CMD3-R3   | *Not implemented yet.*  |
+| CMD3-R4   | *Not implemented yet.*  |
+| CMD3-R5   | *Not implemented yet.*  |
+| CMD3-R6   | *Not implemented yet.*  |
+| CMD3-NR1  | *Not implemented yet.*  |
+| CMD3-NR2  | *Not implemented yet.*  |
 
 
 RecherchePoint v2.0
@@ -69,6 +86,19 @@ RecherchePoint v2.0
 | RP-R3    | `lowatt-enedis search --voie "1 RUE DE LA MER" --nom=TES --cp 84160 --insee 84042 --hp`           |
 | RP-NR1   | `lowatt-enedis search --categorie RES --cp 84160 --insee 84042`                                   |
 | RP-NR2   | `lowatt-enedis search --insee 34231 --voie "1 RUE DE LA MER"`                                     |
+
+
+CommandeAccesDonneesMesures v1.0
+---------------------------------
+
+| Case      | Command                 |
+|-----------|-------------------------|
+| ACCES-R1  | *Not implemented yet.*  |
+| ACCES-R2  | *Not implemented yet.*  |
+| ACCES-R3  | *Not implemented yet.*  |
+| ACCES-R4  | *Not implemented yet.*  |
+| ACCES-NR1 | *Not implemented yet.*  |
+| ACCES-NR2 | *Not implemented yet.*  |
 
 
 CommandeTransmissionDonneesInfraJ v1.0
@@ -117,7 +147,7 @@ RechercherServicesSouscritsMesures v1.0
 | Case          | Command                                      |
 |---------------|----------------------------------------------|
 | RS-R1 (C5)    | `lowatt-enedis subscriptions 25884515170669` |
-| RS-R1 (C1-C4) | `lowatt-enedis subscriptions 98800000000246` |
+| RS-R1 (C2-C4) | `lowatt-enedis subscriptions 98800000000246` |
 
 CommandeArretServiceSouscritMesures v1.0
 ----------------------------------------

--- a/lowatt_enedis/wsdl/CommandeAccesDonneesMesures/Services/CommanderAccesDonneesMesures/CommanderAccesDonneesMesures-V1.0.wsdl
+++ b/lowatt_enedis/wsdl/CommandeAccesDonneesMesures/Services/CommanderAccesDonneesMesures/CommanderAccesDonneesMesures-V1.0.wsdl
@@ -1,0 +1,81 @@
+<wsdl:definitions name="CommanderAccesDonneesMesures-V1.0"
+                  targetNamespace="http://www.enedis.fr/sge/b2b/commandeaccesdonneesmesures/v1.0"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="http://www.enedis.fr/sge/b2b/commandeaccesdonneesmesures/v1.0"
+                  xmlns:ope="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0"
+                  xmlns:dic="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc"
+                  xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0">
+
+    <wsdl:types>
+        <xs:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xs:import schemaLocation="./CommanderAccesDonneesMesures-V1.0.xsd"
+                       namespace="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0"/>
+            <xs:import schemaLocation="./ENEDIS.Dictionnaire.TypeComplexe.v5.0.xsd"
+                       namespace="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc"/>
+            <xs:import schemaLocation="./ENEDIS.Dictionnaire.Technique.v1.0.xsd"
+                       namespace="http://www.enedis.fr/sge/b2b/technique/v1.0"/>
+        </xs:schema>
+    </wsdl:types>
+
+    <!-- Messages -->
+    <wsdl:message name="commanderAccesDonneesMesures">
+        <wsdl:part name="commanderAccesDonneesMesures" element="ope:commanderAccesDonneesMesures"/>
+    </wsdl:message>
+    <wsdl:message name="commanderAccesDonneesMesuresResponse">
+        <wsdl:part name="commanderAccesDonneesMesuresResponse" element="ope:commanderAccesDonneesMesuresResponse"/>
+    </wsdl:message>
+
+    <!-- Erreur -->
+    <wsdl:message name="erreur">
+        <wsdl:part name="Erreur" element="tec:erreur"/>
+    </wsdl:message>
+
+    <!-- Entete -->
+    <wsdl:message name="entete">
+        <wsdl:part name="entete" element="tec:entete"/>
+    </wsdl:message>
+
+    <!-- EnteteRetour -->
+    <wsdl:message name="acquittement">
+        <wsdl:part name="acquittement" element="tec:acquittement"/>
+    </wsdl:message>
+
+    <!-- portType -->
+    <wsdl:portType name="CommanderAccesDonneesMesuresPortType">
+        <wsdl:operation name="commanderAccesDonneesMesures">
+            <wsdl:input message="tns:commanderAccesDonneesMesures" name="commanderAccesDonneesMesures"/>
+            <wsdl:output message="tns:commanderAccesDonneesMesuresResponse"
+                         name="commanderAccesDonneesMesuresResponse"/>
+            <wsdl:fault message="tns:erreur" name="erreur"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <!-- binding -->
+    <wsdl:binding name="CommanderAccesDonneesMesuresBinding" type="tns:CommanderAccesDonneesMesuresPortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <!-- commanderAccesDonneesMesuresITCResponse -->
+        <wsdl:operation name="commanderAccesDonneesMesures">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="commanderAccesDonneesMesures">
+                <soap:body use="literal"/>
+                <soap:header use="literal" part="entete" message="tns:entete"/>
+            </wsdl:input>
+            <wsdl:output name="commanderAccesDonneesMesuresResponse">
+                <soap:body use="literal"/>
+                <soap:header use="literal" part="acquittement" message="tns:acquittement"/>
+            </wsdl:output>
+            <wsdl:fault name="erreur">
+                <soap:fault name="erreur" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <!-- service -->
+    <wsdl:service name="CommanderAccesDonneesMesures-V1.0">
+        <wsdl:port name="CommanderAccesDonneesMesuresPort" binding="tns:CommanderAccesDonneesMesuresBinding">
+            <soap:address location="https://sge-b2b.enedis.fr/CommanderAccesDonneesMesures/v1.0"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>

--- a/lowatt_enedis/wsdl/CommandeAccesDonneesMesures/Services/CommanderAccesDonneesMesures/CommanderAccesDonneesMesures-V1.0.xsd
+++ b/lowatt_enedis/wsdl/CommandeAccesDonneesMesures/Services/CommanderAccesDonneesMesures/CommanderAccesDonneesMesures-V1.0.xsd
@@ -1,0 +1,214 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:sc="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0"
+           targetNamespace="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0" version="1.0.0">
+    <xs:element name="commanderAccesDonneesMesures" type="sc:CommanderAccesDonneesMesuresType"/>
+    <xs:element name="commanderAccesDonneesMesuresResponse" type="sc:CommanderAccesDonneesMesuresResponseType"/>
+    <xs:complexType name="CommanderAccesDonneesMesuresType">
+        <xs:sequence>
+            <xs:element name="demande" type="sc:DemandeType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="CommanderAccesDonneesMesuresResponseType">
+        <xs:sequence>
+            <xs:element name="affaireId" type="sc:AffaireIdType"/>
+            <xs:element name="prestations" type="sc:PrestationsType" minOccurs="0"/>
+            <xs:element name="serviceSouscritId" type="sc:ServiceSouscritIdType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="PrestationFicheType">
+        <xs:sequence>
+            <xs:element name="libelle" type="sc:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" type="sc:PrestationFicheCodeType" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="PrestationOptionType">
+        <xs:sequence>
+            <xs:element name="libelle" type="sc:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" type="sc:PrestationOptionCodeType" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="PrestationCasType">
+        <xs:sequence>
+            <xs:element name="libelle" type="sc:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" type="sc:PrestationCasCodeType" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="PrestationsType">
+        <xs:sequence>
+            <xs:element name="prestation" type="sc:PrestationType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="PrestationType">
+        <xs:sequence>
+            <xs:element name="rang" type="sc:NbEntierType"/>
+            <xs:element name="fiche" type="sc:PrestationFicheType"/>
+            <xs:element name="option" type="sc:PrestationOptionType" minOccurs="0"/>
+            <xs:element name="cas" type="sc:PrestationCasType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="PrestationFicheCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="63"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PrestationOptionCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="63"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PrestationCasCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="63"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ServiceSouscritIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="DemandeType">
+        <xs:sequence>
+            <xs:element name="donneesGenerales" type="sc:DonneesGeneralesType"/>
+            <xs:element name="accesDonnees" type="sc:AccesDonneesType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="DonneesGeneralesType">
+        <xs:sequence>
+            <xs:element name="refExterne" type="sc:Chaine255Type" minOccurs="0"/>
+            <xs:element name="objetCode" type="sc:DemandeObjetCodeType"/>
+            <xs:element name="pointId" type="sc:PointIdType"/>
+            <xs:element name="initiateurLogin" type="sc:UtilisateurLoginType"/>
+            <xs:element name="contrat" type="sc:ContratType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="DeclarationAccordClientType">
+        <xs:sequence>
+            <xs:element name="accord" type="sc:BooleenType"/>
+            <xs:choice minOccurs="0">
+                <xs:element name="personnePhysique" type="sc:PersonnePhysiqueType"/>
+                <xs:element name="personneMorale" type="sc:PersonneMoraleType"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="AccesDonneesType">
+        <xs:sequence>
+            <xs:element name="dateDebut" type="sc:DateType"/>
+            <xs:element name="dateFin" type="sc:DateType" minOccurs="0"/>
+            <xs:element name="declarationAccordClient" type="sc:DeclarationAccordClientType"/>
+            <xs:element name="typeDonnees" type="sc:TypeDonneesType"/>
+            <xs:element name="soutirage" type="sc:BooleenType" minOccurs="0"/>
+            <xs:element name="injection" type="sc:BooleenType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="ContratType">
+        <xs:sequence>
+            <xs:element name="contratId" type="sc:ContratIdType" minOccurs="0"/>
+            <xs:element name="acteurMarcheCode" type="sc:ActeurCodeType" minOccurs="0"/>
+            <xs:element name="contratType" type="sc:ContratTypeType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="Chaine255Type">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AffaireIdType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9A-Z]{4,8}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AdresseEmailType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9a-zA-Z][\-._0-9a-zA-Z]{0,255}@[0-9a-zA-Z][\-._0-9a-zA-Z]{0,255}.[a-zA-Z]{2,63}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="BooleenType">
+        <xs:restriction base="xs:boolean"/>
+    </xs:simpleType>
+    <xs:simpleType name="ContratIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ContratTypeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DateType">
+        <xs:restriction base="xs:date"/>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeObjetCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="3"/>
+            <xs:maxLength value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CiviliteAbreviationType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="M"/>
+            <xs:enumeration value="Mme"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FinaliteCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TypeDonneesType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="10"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="NbEntierType">
+        <xs:restriction base="xs:integer">
+            <xs:totalDigits value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PeriodiciteTransmissionCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PointIdType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{14}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ActeurCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="UtilisateurLoginType">
+        <xs:union memberTypes="sc:UtilisateurNniType sc:AdresseEmailType"/>
+    </xs:simpleType>
+    <xs:simpleType name="UtilisateurNniType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{6}([A-Z0-9]{2})?"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="PersonnePhysiqueType">
+        <xs:sequence>
+            <xs:element name="civilite" type="sc:CiviliteAbreviationType" minOccurs="0"/>
+            <xs:element name="nom" type="sc:Chaine255Type"/>
+            <xs:element name="prenom" type="sc:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="PersonneMoraleType">
+        <xs:sequence>
+            <xs:element name="denominationSociale" type="sc:Chaine255Type"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/lowatt_enedis/wsdl/CommandeAccesDonneesMesures/Services/CommanderAccesDonneesMesures/ENEDIS.Dictionnaire.Technique.v1.0.xsd
+++ b/lowatt_enedis/wsdl/CommandeAccesDonneesMesures/Services/CommanderAccesDonneesMesures/ENEDIS.Dictionnaire.Technique.v1.0.xsd
@@ -1,0 +1,98 @@
+<xs:schema targetNamespace="http://www.enedis.fr/sge/b2b/technique/v1.0" version="1.0.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0"
+           xmlns:tns="http://schemas.xmlsoap.org/soap/envelope/">
+    <xs:import namespace="http://schemas.xmlsoap.org/soap/envelope/"
+               schemaLocation="./W3C.SoapEnv.xsd"/>
+    <xs:complexType name="AcquittementType">
+        <xs:sequence>
+            <xs:element name="resultat" type="tec:ResultatType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="infoFonctionnelles" type="tec:InfoFonctionnellesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="infoDemandeur" type="tec:InfoDemandeurType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="ResultatType">
+        <xs:simpleContent>
+            <xs:extension base="tec:ResultatLibelleType">
+                <xs:attribute name="code" use="required" type="tec:ResultatCodeType"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="ErreurType">
+        <xs:sequence>
+            <xs:element name="resultat" type="tec:ResultatType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="infoFonctionnelles" type="tec:InfoFonctionnellesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="infoDemandeur" type="tec:InfoDemandeurType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="commentaire" type="tec:ErreurCommentaireType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="erreur" type="tec:ErreurType"/>
+    <xs:element name="acquittement" type="tec:AcquittementType"/>
+    <xs:complexType name="EnteteType">
+        <xs:sequence>
+            <xs:element name="version" type="tec:VersionType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="infoFonctionnelles" type="tec:InfoFonctionnellesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="infoDemandeur" type="tec:InfoDemandeurType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute use="optional" ref="tns:mustUnderstand"/>
+    </xs:complexType>
+    <xs:element name="entete" type="tec:EnteteType"/>
+    <xs:complexType name="InfoDemandeurType">
+        <xs:sequence>
+            <xs:element name="loginDemandeur" type="tec:DemandeurAdresseEmailType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="appelDemandeurId" type="tec:DemandeurAppelIdType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="referenceDemandeur" type="tec:DemandeurRefFrnType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="referenceDemandeurGroupee" type="tec:DemandeurRefFrnType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="ResultatCodeType">
+        <xs:restriction base="xs:string">
+            <xs:length value="6"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ResultatLibelleType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="VersionType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[1-9][0-9]*.[0-9]+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ErreurCommentaireType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="2047"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeurAdresseEmailType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9a-zA-Z][\-._0-9a-zA-Z]{0,255}@[0-9a-zA-Z][\-._0-9a-zA-Z]{1,255}.[a-zA-Z]{2,63}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeurRefFrnType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeurAppelIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="InfoFonctionnellesType">
+        <xs:sequence>
+            <xs:element name="pointId" type="tec:ObjetIdType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="affaireId" type="tec:ObjetIdType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="ObjetIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="20"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/lowatt_enedis/wsdl/CommandeAccesDonneesMesures/Services/CommanderAccesDonneesMesures/ENEDIS.Dictionnaire.TypeComplexe.v5.0.xsd
+++ b/lowatt_enedis/wsdl/CommandeAccesDonneesMesures/Services/CommanderAccesDonneesMesures/ENEDIS.Dictionnaire.TypeComplexe.v5.0.xsd
@@ -1,0 +1,869 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dc="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc"
+           xmlns:ds="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/ds"
+           targetNamespace="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc" version="5.2.0">
+    <xs:import namespace="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/ds"
+               schemaLocation="ENEDIS.Dictionnaire.TypeSimple.v5.0.xsd"/>
+    <xs:complexType name="AcceptabiliteResultatType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:AcceptabiliteResultatCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="AcheminementTarifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:AcheminementTarifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ActiviteSecteurType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ActiviteSecteurCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ActiviteType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ActiviteCodeNafType"/>
+    </xs:complexType>
+    <xs:complexType name="AdresseAfnorType">
+        <xs:sequence>
+            <xs:element name="ligne1" type="ds:AdresseAfnorLigneType" minOccurs="0"/>
+            <xs:element name="ligne2" type="ds:AdresseAfnorLigneType" minOccurs="0"/>
+            <xs:element name="ligne3" type="ds:AdresseAfnorLigneType" minOccurs="0"/>
+            <xs:element name="ligne4" type="ds:AdresseAfnorLigneType" minOccurs="0"/>
+            <xs:element name="ligne5" type="ds:AdresseAfnorLigneType" minOccurs="0"/>
+            <xs:element name="ligne6" type="ds:AdresseAfnorLigneType"/>
+            <xs:element name="ligne7" type="ds:AdresseAfnorLigneType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="AffaireAnnulationMotifRefusType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:AffaireAnnulationMotifRefusCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="AffaireAnnulationMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:AffaireAnnulationMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="AffaireClotureMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:AffaireClotureMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="AffaireEtatType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:AffaireEtatCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="AffaireModificationMotifRefusType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+            <xs:element name="code" type="ds:AffaireModificationMotifRefusCodeType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="AffaireNatureModificationType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+            <xs:element name="code" type="ds:AffaireNatureModificationCodeType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="AffaireStatutType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:AffaireStatutCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="AlimentationEtatType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:AlimentationEtatCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="AlimentationModeApresCompteurType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:AlimentationModeApresCompteurCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="AlimentationSecoursModeBasculeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:AlimentationSecoursModeBasculeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ApplicationType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ApplicationCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="AutoconsommationIndividuelleType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:AutoconsommationIndividuelleCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="BilanContinuiteFournitureCoupureTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:OptionBilanContinuiteFournitureCoupureTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="BilanContinuiteFournitureTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:OptionBilanContinuiteFournitureTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="CalendrierType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:CalendrierCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="CentreGeographiqueType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:CentreGeographiqueCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="CircuitTempoType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:CircuitTempoCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ClasseTemporelleType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ClasseTemporelleCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ClientFinalCategorieType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ClientFinalCategorieCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ClientPrioritaireTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ClientPrioritaireTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="CommuneFranceType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:CommuneFranceCodeInseeType"/>
+    </xs:complexType>
+    <xs:complexType name="CompteurIntensiteNominaleType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:CompteurIntensiteNominaleCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="CompteurSousTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:CompteurModeleSousTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="CompteurTensionNominaleType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:CompteurTensionNominaleCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ConsommationTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ConsommationTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ConsuelMotifNonExigibiliteType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ConsuelMotifNonExigibiliteCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ContratTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ContratTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="CoordonnesGpsType">
+        <xs:sequence>
+            <xs:element name="latitude" type="ds:NbDecimalType"/>
+            <xs:element name="longitude" type="ds:NbDecimalType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="CoupureLocalisationType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:CoupureLocalisationCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="CoupureMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:CoupureMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="CourrierModeleType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:CourrierModeleCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="CreneauHoraireType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:CreneauHoraireCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DemandeChangementFrnCorrectifMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DemandeChangementFrnCorrectifMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DemandeCommunicationDistributeurTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DemandeCommunicationDistributeurTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DemandeDiverseComptageTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DemandeDiverseComptageTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DemandeDiverseInformationsTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DemandeDiverseInformationsTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DemandeDiverseQualiteFournitureTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DemandeDiverseQualiteFournitureTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DemandeDiverseReseauTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DemandeDiverseReseauTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DemandeMediaType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DemandeMediaCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DemandeMiseEnServiceCorrectiveMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DemandeMiseEnServiceCorrectifMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DemandeObjetType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DemandeObjetCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DemandeTechniqueTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DemandeTechniqueTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DisjoncteurCalibreType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DisjoncteurCalibreCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DisjoncteurNatureType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DisjoncteurNatureCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DispositifComptageParticulariteType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DispositifComptageParticulariteCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DispositifParticulierLimitationPerturbationsType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DispositifParticulierLimitationPerturbationsCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DomaineTensionType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DomaineTensionCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="DureeType">
+        <xs:sequence>
+            <xs:element name="valeur" type="ds:NbDecimalType"/>
+            <xs:element name="unite" type="ds:DureeUniteSymboleType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="DysfonctionnementNatureType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:DysfonctionnementNatureCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="EntrepriseCategorieType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:EntrepriseCategorieTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="EquipementElectriqueLocalisationType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:EquipementElectriqueLocalisationCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="EquipementElectriqueRegimeProprieteType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:EquipementElectriqueRegimeProprieteCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="FaisabiliteMotifImpossibiliteType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="optional" type="ds:FaisabiliteMotifImpossibiliteCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="FaisabiliteReserveMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:FaisabiliteReserveMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="FaisabiliteResultatType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:BooleenType"/>
+    </xs:complexType>
+    <xs:complexType name="FinaliteType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:FinaliteCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="FormeJuridiqueType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:FormeJuridiqueCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="FraisType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:FraisCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="FraudeNatureType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:FraudeNatureCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="FraudeOuDysfonctionnementMethodeCalculType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:FraudeOuDysfonctionnementMethodeCalculCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="FraudeOuDysfonctionnementnMethodeFacturationType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:FraudeOuDysfonctionnementMethodeFacturationCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="GeneriqueType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:Chaine15Type"/>
+    </xs:complexType>
+    <xs:complexType name="GrandeurPhysiqueType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:GrandeurPhysiqueCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="GroupePeriodeMobileType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:GroupePeriodeMobileCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="IntensiteType">
+        <xs:sequence>
+            <xs:element name="valeur" type="ds:NbDecimalType"/>
+            <xs:element name="unite" type="ds:IntensiteUniteSymboleType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="IntervenantTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:IntervenantTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="InterventionDemandeMotifRefusType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:InterventionDemandeMotifRefusCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="InterventionDeplanificationMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:InterventionDeplanificationMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="InterventionEtatType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:InterventionEtatCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="InterventionNonRealisationMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:InterventionNonRealisationMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="InterventionPeriodeTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:InterventionPeriodeTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="InterventionPlanificationHorsDelaiMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:InterventionPlanificationHorsDelaiMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="InterventionRealisationEtatType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:InterventionRealisationEtatCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="InterventionReplanificationMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:InterventionReplanificationMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="LigneFraisType">
+        <xs:sequence>
+            <xs:element name="frais" type="dc:FraisType"/>
+            <xs:element name="quantite" type="ds:NbEntierType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="LignesFraisType">
+        <xs:sequence>
+            <xs:element name="ligneFrais" type="dc:LigneFraisType" maxOccurs="200"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="LimiteurTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:LimiteurTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="LongueurType">
+        <xs:sequence>
+            <xs:element name="valeur" type="ds:NbDecimalType"/>
+            <xs:element name="unite" type="ds:LongueurUniteSymboleType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="MesureDeclencheurType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:MesureDeclencheurCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="MesureNatureType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:MesureNatureCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="MesureOrigineType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:MesureOrigineCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="MesureStatutType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:MesureStatutCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="MesureTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:MesureTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="MontantType">
+        <xs:sequence>
+            <xs:element name="valeur" type="ds:NbDecimalType"/>
+            <xs:element name="unite" type="ds:DeviseAbreviationType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="NomenclatureActiviteEconomiqueEuropeenneType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:NomenclatureActiviteEconomiqueEuropeenneTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="NonPriseEnCompteAutoreleveMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:NonPriseEnCompteAutoreleveMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="OffreTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:OffreTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="OperationType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:OperationCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PeriodiciteType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:PeriodiciteCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PlageHeuresCreusesType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:PlageHeuresCreusesCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PointAppartenanceRegroupementHebergeurDecomptantType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:PointAppartenanceRegroupementHebergeurDecomptantCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PointAppartenanceRegroupementTurpeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:PointAppartenanceRegroupementTurpeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PointEtatContractuelType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:PointEtatContractuelCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PointSegmentClienteleType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:PointSegmentClienteleCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PrejudiceNatureType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:PrejudiceNatureCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PrestationCasType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:PrestationCasCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PrestationFacturationType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:BooleenType"/>
+    </xs:complexType>
+    <xs:complexType name="PrestationFicheType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:PrestationFicheCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PrestationMotifNonFacturationType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:PrestationMotifNonFacturationCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PrestationMotifNonRealisationType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:PrestationMotifNonRealisationCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PrestationOptionType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:PrestationOptionCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PrestationRealisationType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:BooleenType"/>
+    </xs:complexType>
+    <xs:complexType name="ProductionAutonomeCouplageModeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ProductionAutonomeCouplageModeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ProductionCombustibleType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ProductionCombustibleTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ProductionFiliereType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ProductionFiliereTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ProductionTechnologieType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ProductionTechnologieTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ProgrammeCircuitChauffageTempoType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ProgrammeCircuitChauffageTempoCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ProgrammeCircuitEauTempoType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ProgrammeCircuitEauTempoCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="PuissanceType">
+        <xs:sequence>
+            <xs:element name="valeur" type="ds:NbDecimalType"/>
+            <xs:element name="unite" type="ds:PuissanceUniteSymboleType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="RattachementPointRoleType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:RattachementPointRoleCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="RattachementTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:RattachementTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="RecevabiliteMotifRefusType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:RecevabiliteMotifRefusCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="RecevabilitePremiereMiseEnServicePourEssaiMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:RecevabilitePremiereMiseEnServicePourEssaiMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="RecevabiliteResultatType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:RecevabiliteResultatCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ReclamationSousTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ReclamationSousTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ReclamationTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ReclamationTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="RectificationMotifType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:RectificationMotifCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="RelaisCommandeTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:RelaisCommandeTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="RelaisNatureType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:RelaisNatureCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ReleveMediaType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ReleveMediaCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ReleveModeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ReleveModeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="RelevePlageType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:RelevePlageCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ReleveQualificationType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ReleveQualificationCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ReleveTraitementModeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ReleveTraitementModeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ResidenceTypeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ResidenceTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="SecteurGeographiqueType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:SecteurGeographiqueCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="SituationContractuelleGestionModeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:SituationContractuelleGestionModeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="StructureComptageType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:StructureComptageCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="StructureTarifaireContexteUtilisationType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:StructureTarifaireContexteUtilisationCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="TensionLivraisonType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:TensionLivraisonCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="TensionType">
+        <xs:sequence>
+            <xs:element name="valeur" type="ds:NbDecimalType"/>
+            <xs:element name="unite" type="ds:TensionUniteSymboleType"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="TourneeType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:TourneeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="TransformateurCalibreType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:TransformateurCalibreCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="TransformateurCouplageType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:TransformateurCouplageTypeCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="TransformateurCourantPositionType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:TransformateurCourantPositionCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="TransformateurPrecisionClasseType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:TransformateurPrecisionClasseCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="UsageChantierType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:UsageChantierCodeType"/>
+    </xs:complexType>
+    <xs:complexType name="ZoneQualiteDesserteType">
+        <xs:sequence>
+            <xs:element name="libelle" type="ds:Chaine255Type" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" use="required" type="ds:ZoneQualiteDesserteCodeType"/>
+    </xs:complexType>
+</xs:schema>

--- a/lowatt_enedis/wsdl/CommandeAccesDonneesMesures/Services/CommanderAccesDonneesMesures/ENEDIS.Dictionnaire.TypeSimple.v5.0.xsd
+++ b/lowatt_enedis/wsdl/CommandeAccesDonneesMesures/Services/CommanderAccesDonneesMesures/ENEDIS.Dictionnaire.TypeSimple.v5.0.xsd
@@ -1,0 +1,1198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/ds"
+           targetNamespace="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/ds" version="5.2.0">
+    <xs:simpleType name="AcceptabiliteResultatCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AcheminementTarifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ActeurCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ActiviteCodeNafType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9A-Za-z]{1,5}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ActiviteSecteurCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AdresseAfnorLigneType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="38"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AdresseEmailType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9a-zA-Z][\-._0-9a-zA-Z]{0,255}@[0-9a-zA-Z][\-._0-9a-zA-Z]{1,255}.[a-zA-Z]{2,63}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AffaireAnnulationMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AffaireAnnulationMotifRefusCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AffaireClotureMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AffaireEtatCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AffaireIdType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9A-Z]{4,8}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AffaireModificationMotifRefusCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AffaireNatureModificationCodeType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="AffaireStatutCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ANNUL"/>
+            <xs:enumeration value="COURS"/>
+            <xs:enumeration value="TERMN"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AlimentationEtatCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ALIM"/>
+            <xs:enumeration value="COUP"/>
+            <xs:enumeration value="LIMI"/>
+            <xs:enumeration value="NRAC"/>
+            <xs:enumeration value="NALI"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AlimentationModeApresCompteurCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AlimentationSecoursModeBasculeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AnneeType">
+        <xs:restriction base="xs:gYear"/>
+    </xs:simpleType>
+    <xs:simpleType name="ApplicationCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AutoconsommationIndividuelleCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="BooleenType">
+        <xs:restriction base="xs:boolean"/>
+    </xs:simpleType>
+    <xs:simpleType name="CalendrierCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CalendrierJourTypeCategorieCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z1-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CalendrierJourTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z1-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CentreGeographiqueCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="11"/>
+            <xs:enumeration value="12"/>
+            <xs:enumeration value="121"/>
+            <xs:enumeration value="122"/>
+            <xs:enumeration value="124"/>
+            <xs:enumeration value="125"/>
+            <xs:enumeration value="13"/>
+            <xs:enumeration value="14"/>
+            <xs:enumeration value="142"/>
+            <xs:enumeration value="143"/>
+            <xs:enumeration value="144"/>
+            <xs:enumeration value="145"/>
+            <xs:enumeration value="146"/>
+            <xs:enumeration value="147"/>
+            <xs:enumeration value="148"/>
+            <xs:enumeration value="15"/>
+            <xs:enumeration value="151"/>
+            <xs:enumeration value="152"/>
+            <xs:enumeration value="154"/>
+            <xs:enumeration value="155"/>
+            <xs:enumeration value="16"/>
+            <xs:enumeration value="161"/>
+            <xs:enumeration value="162"/>
+            <xs:enumeration value="163"/>
+            <xs:enumeration value="164"/>
+            <xs:enumeration value="165"/>
+            <xs:enumeration value="171"/>
+            <xs:enumeration value="172"/>
+            <xs:enumeration value="173"/>
+            <xs:enumeration value="175"/>
+            <xs:enumeration value="176"/>
+            <xs:enumeration value="177"/>
+            <xs:enumeration value="179"/>
+            <xs:enumeration value="191"/>
+            <xs:enumeration value="193"/>
+            <xs:enumeration value="194"/>
+            <xs:enumeration value="195"/>
+            <xs:enumeration value="196"/>
+            <xs:enumeration value="197"/>
+            <xs:enumeration value="198"/>
+            <xs:enumeration value="199"/>
+            <xs:enumeration value="21"/>
+            <xs:enumeration value="211"/>
+            <xs:enumeration value="212"/>
+            <xs:enumeration value="213"/>
+            <xs:enumeration value="214"/>
+            <xs:enumeration value="215"/>
+            <xs:enumeration value="22"/>
+            <xs:enumeration value="221"/>
+            <xs:enumeration value="222"/>
+            <xs:enumeration value="223"/>
+            <xs:enumeration value="224"/>
+            <xs:enumeration value="225"/>
+            <xs:enumeration value="23"/>
+            <xs:enumeration value="231"/>
+            <xs:enumeration value="232"/>
+            <xs:enumeration value="233"/>
+            <xs:enumeration value="234"/>
+            <xs:enumeration value="235"/>
+            <xs:enumeration value="24"/>
+            <xs:enumeration value="241"/>
+            <xs:enumeration value="242"/>
+            <xs:enumeration value="243"/>
+            <xs:enumeration value="245"/>
+            <xs:enumeration value="25"/>
+            <xs:enumeration value="251"/>
+            <xs:enumeration value="252"/>
+            <xs:enumeration value="253"/>
+            <xs:enumeration value="254"/>
+            <xs:enumeration value="256"/>
+            <xs:enumeration value="258"/>
+            <xs:enumeration value="259"/>
+            <xs:enumeration value="26"/>
+            <xs:enumeration value="41"/>
+            <xs:enumeration value="42"/>
+            <xs:enumeration value="43"/>
+            <xs:enumeration value="45"/>
+            <xs:enumeration value="51"/>
+            <xs:enumeration value="52"/>
+            <xs:enumeration value="54"/>
+            <xs:enumeration value="55"/>
+            <xs:enumeration value="56"/>
+            <xs:enumeration value="63"/>
+            <xs:enumeration value="64"/>
+            <xs:enumeration value="65"/>
+            <xs:enumeration value="71"/>
+            <xs:enumeration value="72"/>
+            <xs:enumeration value="73"/>
+            <xs:enumeration value="74"/>
+            <xs:enumeration value="75"/>
+            <xs:enumeration value="91"/>
+            <xs:enumeration value="92"/>
+            <xs:enumeration value="93"/>
+            <xs:enumeration value="94"/>
+            <xs:enumeration value="95"/>
+            <xs:enumeration value="96"/>
+            <xs:enumeration value="97"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Chaine15Type">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Chaine2047Type">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="2047"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Chaine255Type">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CircuitTempoCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CiviliteAbreviationType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ClasseTemporelleCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CleTeleAccesType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ClientFinalCategorieCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="PRO"/>
+            <xs:enumeration value="RES"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ClientPrioritaireTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CodeEicType">
+        <xs:restriction base="xs:string">
+            <xs:length value="16"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CodePostalFrancaisType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{5}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CommuneFranceCodeInseeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9A-Z]{5}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CompteurIntensiteNominaleCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CompteurModeleSousTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CompteurTensionNominaleCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CompteurTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ConsommationTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="FACTU"/>
+            <xs:enumeration value="MOYEN"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ConsuelMotifNonExigibiliteCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ContratIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ContratTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CARDE"/>
+            <xs:enumeration value="CARDI"/>
+            <xs:enumeration value="CARDS"/>
+            <xs:enumeration value="CIP"/>
+            <xs:enumeration value="CRAE"/>
+            <xs:enumeration value="CSD"/>
+            <xs:enumeration value="GRDAA"/>
+            <xs:enumeration value="GRDAO"/>
+            <xs:enumeration value="GRDEC"/>
+            <xs:enumeration value="GRDF"/>
+            <xs:enumeration value="GRDOE"/>
+            <xs:enumeration value="GRDRE"/>
+            <xs:enumeration value="GRDT"/>
+            <xs:enumeration value="PGIAP"/>
+            <xs:enumeration value="PR101"/>
+            <xs:enumeration value="PR501"/>
+            <xs:enumeration value="PR541"/>
+            <xs:enumeration value="PR549"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CoupureLocalisationCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CoupureMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CourrierIdType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CourrierModeleCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CourrierMotifNonDistributionCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CourrierStatutCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CourrierTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CreneauHoraireCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DateHeureType">
+        <xs:restriction base="xs:dateTime"/>
+    </xs:simpleType>
+    <xs:simpleType name="DateType">
+        <xs:restriction base="xs:date"/>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeChangementFrnCorrectifMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{4,10}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeCommunicationDistributeurTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeDiverseComptageTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeDiverseInformationsTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeDiverseQualiteFournitureTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeDiverseReseauTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeMediaCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeMiseEnServiceCorrectifMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeObjetCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeTechniqueTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DeviseAbreviationType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DisjoncteurCalibreCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DisjoncteurNatureCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DispositifComptageParticulariteCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DispositifParticulierLimitationPerturbationsCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DomaineTensionCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="BTINF"/>
+            <xs:enumeration value="BTSUP"/>
+            <xs:enumeration value="HTA"/>
+            <xs:enumeration value="HTB"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DureeUniteSymboleType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="annee"/>
+            <xs:enumeration value="h"/>
+            <xs:enumeration value="jour"/>
+            <xs:enumeration value="min"/>
+            <xs:enumeration value="mois"/>
+            <xs:enumeration value="ms"/>
+            <xs:enumeration value="s"/>
+            <xs:enumeration value="semaine"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DysfonctionnementNatureCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="EntrepriseCategorieTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="EquipementElectriqueLocalisationCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="EquipementElectriqueRegimeProprieteCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="EtablissementNumSiretType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{14}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FaisabiliteMotifImpossibiliteCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FaisabiliteReserveMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FichierIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FichierNomType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\S{1,120}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FinaliteCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FormeJuridiqueCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="AA"/>
+            <xs:enumeration value="AC"/>
+            <xs:enumeration value="AE"/>
+            <xs:enumeration value="ASSO"/>
+            <xs:enumeration value="CA"/>
+            <xs:enumeration value="EARL"/>
+            <xs:enumeration value="EI"/>
+            <xs:enumeration value="EIRL"/>
+            <xs:enumeration value="EURL"/>
+            <xs:enumeration value="FO"/>
+            <xs:enumeration value="GIE"/>
+            <xs:enumeration value="GIP"/>
+            <xs:enumeration value="II"/>
+            <xs:enumeration value="PL"/>
+            <xs:enumeration value="SA"/>
+            <xs:enumeration value="SARL"/>
+            <xs:enumeration value="SAS"/>
+            <xs:enumeration value="SASU"/>
+            <xs:enumeration value="SCA"/>
+            <xs:enumeration value="SCEA"/>
+            <xs:enumeration value="SCF"/>
+            <xs:enumeration value="SCI"/>
+            <xs:enumeration value="SCM"/>
+            <xs:enumeration value="SCOP"/>
+            <xs:enumeration value="SCP"/>
+            <xs:enumeration value="SCS"/>
+            <xs:enumeration value="SEL"/>
+            <xs:enumeration value="SEP"/>
+            <xs:enumeration value="SNC"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FraisCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FraudeNatureCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FraudeOuDysfonctionnementMethodeCalculCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FraudeOuDysfonctionnementMethodeFacturationCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="GrandeurMetierCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="GrandeurPhysiqueCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="GroupePeriodeMobileCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="HeureType">
+        <xs:restriction base="xs:time"/>
+    </xs:simpleType>
+    <xs:simpleType name="IndexUniteSymboleType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-zA-Z]{1,5}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="InstallationCaracteristiqueTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="IntensiteUniteSymboleType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="A"/>
+            <xs:enumeration value="mA"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="IntervenantTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="5"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="InterventionDemandeMotifRefusCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="InterventionDeplanificationMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="InterventionEtatCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ANNUL"/>
+            <xs:enumeration value="CLOS"/>
+            <xs:enumeration value="DMND"/>
+            <xs:enumeration value="PLAN"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="InterventionNonRealisationMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="InterventionPeriodeTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="HEOE"/>
+            <xs:enumeration value="HHOE"/>
+            <xs:enumeration value="HHOS"/>
+            <xs:enumeration value="HHOW"/>
+            <xs:enumeration value="HHSW"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="InterventionPlanificationHorsDelaiMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="InterventionRealisationEtatCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="NREA"/>
+            <xs:enumeration value="PREA"/>
+            <xs:enumeration value="REAL"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="InterventionReplanificationMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="JourDuMoisType">
+        <xs:restriction base="xs:gDay"/>
+    </xs:simpleType>
+    <xs:simpleType name="LibelleAffichageCompteurType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Za-z0-9 _\-]{1,16}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="LigneTelephoniqueNumType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9\+\(\)\s\.]{1,25}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="LimiteurTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="LongueurUniteSymboleType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="km"/>
+            <xs:enumeration value="m"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MesureDeclencheurCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MesureNatureCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MesureOrigineCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MesureStatutCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MesureTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{3,10}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MesureUniteSymboleType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="7"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MoisEtJourType">
+        <xs:restriction base="xs:gMonthDay"/>
+    </xs:simpleType>
+    <xs:simpleType name="MoisType">
+        <xs:restriction base="xs:gMonth"/>
+    </xs:simpleType>
+    <xs:simpleType name="NbDecimalType">
+        <xs:restriction base="xs:decimal">
+            <xs:fractionDigits value="15"/>
+            <xs:totalDigits value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="NbEntierStrictementPositifType">
+        <xs:restriction base="xs:positiveInteger">
+            <xs:totalDigits value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="NbEntierType">
+        <xs:restriction base="xs:integer">
+            <xs:totalDigits value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="NiveauOuvertureServicesCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{1}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="NomenclatureActiviteEconomiqueEuropeenneTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="NonPriseEnCompteAutoreleveMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OffreTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="NO"/>
+            <xs:enumeration value="OH"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OperationCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OptionBilanContinuiteFournitureCoupureTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OptionBilanContinuiteFournitureTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OptionContractuelleSouscriteIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PeriodiciteCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PersonneMoraleNumSirenType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{9}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PlageHeuresCreusesCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PointAppartenanceRegroupementHebergeurDecomptantCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="DECO"/>
+            <xs:enumeration value="HEBE"/>
+            <xs:enumeration value="NON"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PointAppartenanceRegroupementTurpeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="NON"/>
+            <xs:enumeration value="REGT"/>
+            <xs:enumeration value="RGPT"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PointEtatContractuelCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ECRAC"/>
+            <xs:enumeration value="INACCE"/>
+            <xs:enumeration value="ECRES"/>
+            <xs:enumeration value="IMPRO"/>
+            <xs:enumeration value="RESIL"/>
+            <xs:enumeration value="SERVC"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PointIdType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{14}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PointSegmentClienteleCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="C2"/>
+            <xs:enumeration value="C3"/>
+            <xs:enumeration value="C4"/>
+            <xs:enumeration value="C5"/>
+            <xs:enumeration value="INDET"/>
+            <xs:enumeration value="C1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PosteHoraireCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PrejudiceNatureCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PrestationCasCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="63"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PrestationEnvisageeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CFN"/>
+            <xs:enumeration value="MES"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PrestationFicheCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="63"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PrestationMotifNonFacturationCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PrestationMotifNonRealisationCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PrestationOptionCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="63"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ProductionAutonomeCouplageModeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ProductionCombustibleTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9A-Z\.]{1,10}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ProductionFiliereTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9A-Z\.]{1,10}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ProductionTechnologieTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9A-Z\.]{1,10}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ProgrammeCircuitChauffageTempoCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ProgrammeCircuitEauTempoCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{1,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PuissanceUniteSymboleType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="kVA"/>
+            <xs:enumeration value="kWc"/>
+            <xs:enumeration value="kVAR"/>
+            <xs:enumeration value="kW"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RattachementIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RattachementPointRoleCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RattachementTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RecevabiliteMotifRefusCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RecevabilitePremiereMiseEnServicePourEssaiMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RecevabiliteResultatCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ReclamationSousTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ReclamationTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RectificationMotifCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RefCompteurType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RelaisCommandeTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RelaisNatureCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ReleveMediaCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ReleveModeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RelevePlageCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ReleveQualificationCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ReleveTraitementModeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ResidenceTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="PRP"/>
+            <xs:enumeration value="SEC"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="SecteurGeographiqueCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="4"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="SituationContractuelleGestionModeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="INT"/>
+            <xs:enumeration value="GRD"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="StructureComptageCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="StructureTarifaireContexteUtilisationCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TensionLivraisonCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TensionUniteSymboleType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="kV"/>
+            <xs:enumeration value="V"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TourneeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9A-Z]{2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TransformateurCalibreCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TransformateurCouplageTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TransformateurCourantPositionCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TransformateurPrecisionClasseCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="UsageChantierCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="5"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="UtilisateurLoginType">
+        <xs:union memberTypes="ds:AdresseEmailType"/>
+    </xs:simpleType>
+    <xs:simpleType name="ZoneQualiteDesserteCodeType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+</xs:schema>

--- a/lowatt_enedis/wsdl/CommandeAccesDonneesMesures/Services/CommanderAccesDonneesMesures/W3C.SoapEnv.xsd
+++ b/lowatt_enedis/wsdl/CommandeAccesDonneesMesures/Services/CommanderAccesDonneesMesures/W3C.SoapEnv.xsd
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Schema for the SOAP/1.1 envelope
+
+Portions © 2001 DevelopMentor.
+© 2001 W3C (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved.
+
+This document is governed by the W3C Software License [1] as described in the FAQ [2].
+[1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+[2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+By obtaining, using and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions:
+
+Permission to use, copy, modify, and distribute this software and its documentation, with or without modification,  for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the software and documentation or portions thereof, including modifications, that you make:
+
+1.  The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
+
+2.  Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, a short notice of the following form (hypertext is preferred, text is permitted) should be used within the body of any redistributed or derivative code: "Copyright © 2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/"
+
+3.  Notice of any changes or modifications to the W3C files, including the date changes were made. (We recommend you provide URIs to the location from which the code is derived.)
+
+Original W3C files; http://www.w3.org/2001/06/soap-envelope
+Changes made:
+     - reverted namespace to http://schemas.xmlsoap.org/soap/envelope/
+     - reverted mustUnderstand to only allow 0 and 1 as lexical values
+	 - made encodingStyle a global attribute 20020825
+	 - removed default value from mustUnderstand attribute declaration
+
+THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENTATION.
+
+The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to the software without specific, written prior permission. Title to copyright in this software and any associated documentation will at all times remain with copyright holders.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.xmlsoap.org/soap/envelope/"
+           targetNamespace="http://schemas.xmlsoap.org/soap/envelope/">
+
+
+    <!-- Envelope, header and body -->
+    <xs:element name="Envelope" type="tns:Envelope"/>
+    <xs:complexType name="Envelope">
+        <xs:sequence>
+            <xs:element ref="tns:Header" minOccurs="0"/>
+            <xs:element ref="tns:Body" minOccurs="1"/>
+            <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+
+    <xs:element name="Header" type="tns:Header"/>
+    <xs:complexType name="Header">
+        <xs:sequence>
+            <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+
+    <xs:element name="Body" type="tns:Body"/>
+    <xs:complexType name="Body">
+        <xs:sequence>
+            <xs:any namespace="##any" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>
+                    Prose in the spec does not specify that attributes are allowed on the Body element
+                </xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+
+    <!-- Global Attributes.  The following attributes are intended to be usable via qualified attribute names on any complex type referencing them.  -->
+    <xs:attribute name="mustUnderstand">
+        <xs:simpleType>
+            <xs:restriction base="xs:boolean">
+                <xs:pattern value="0|1"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="actor" type="xs:anyURI"/>
+
+    <xs:simpleType name="encodingStyle">
+        <xs:annotation>
+            <xs:documentation>
+                'encodingStyle' indicates any canonicalization conventions followed in the contents of the containing
+                element. For example, the value 'http://schemas.xmlsoap.org/soap/encoding/' indicates the pattern
+                described in SOAP specification
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:anyURI"/>
+    </xs:simpleType>
+
+    <xs:attribute name="encodingStyle" type="tns:encodingStyle"/>
+    <xs:attributeGroup name="encodingStyle">
+        <xs:attribute ref="tns:encodingStyle"/>
+    </xs:attributeGroup>
+
+    <xs:element name="Fault" type="tns:Fault"/>
+    <xs:complexType name="Fault" final="extension">
+        <xs:annotation>
+            <xs:documentation>
+                Fault reporting structure
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="faultcode" type="xs:QName"/>
+            <xs:element name="faultstring" type="xs:string"/>
+            <xs:element name="faultactor" type="xs:anyURI" minOccurs="0"/>
+            <xs:element name="detail" type="tns:detail" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="detail">
+        <xs:sequence>
+            <xs:any namespace="##any" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/lowatt_enedis/wsdl/ConsultationMesuresDetailleesV3/ADAM.ConsulterMesuresDetailleesCommun.xsd
+++ b/lowatt_enedis/wsdl/ConsultationMesuresDetailleesV3/ADAM.ConsulterMesuresDetailleesCommun.xsd
@@ -1,0 +1,261 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:sc="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common"
+           targetNamespace="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" version="1.0.0">
+    <!-- Demande CMDv3  -->
+    <xs:element name="consulterMesuresDetailleesV3" type="sc:ConsulterMesuresDetailleesV3Type"/>
+
+    <!-- Reponse CMDv3  -->
+    <xs:element name="consulterMesuresDetailleesResponseV3" type="sc:ConsulterMesuresDetailleesV3ResponseType"/>
+
+    <!-- Demande CMDv3  -->
+    <xs:complexType name="ConsulterMesuresDetailleesV3Type">
+        <xs:sequence>
+            <xs:element name="demande" type="sc:Demande"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Demande">
+        <xs:sequence>
+            <xs:element name="initiateurLogin" type="xs:string"/>
+            <xs:element name="pointId" type="sc:PointIdType"/>
+            <xs:element name="mesuresTypeCode" type="sc:MesuresTypeCodeType"/>
+            <xs:element name="grandeurPhysique" type="xs:string"/>
+            <xs:element name="dateDebut" type="xs:date"/>
+            <xs:element name="dateFin" type="xs:date"/>
+            <xs:element name="mesuresPas" type="sc:MesuresPasType" minOccurs="0"/>
+            <xs:element name="mesuresCorrigees" type="xs:boolean"/>
+            <xs:element name="sens" type="sc:SensMesureType"/>
+            <xs:element name="cadreAcces" type="sc:CadreAccesType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Information CMDv3 pour demande & réponse-->
+    <xs:simpleType name="PointIdType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{14}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Information CMDv3 pour demande -->
+    <xs:simpleType name="MesuresTypeCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="COURBE"/>
+            <xs:enumeration value="PMAX"/>
+            <xs:enumeration value="ENERGIE"/>
+            <xs:enumeration value="INDEX"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Information CMDv3 pour demande -->
+    <xs:simpleType name="MesuresPasType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="P1D"/>
+            <xs:enumeration value="P1M"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Information CMDv3 pour demande -->
+    <xs:simpleType name="SensMesureType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="INJECTION"/>
+            <xs:enumeration value="SOUTIRAGE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Information CMDv3 pour demande -->
+    <xs:simpleType name="CadreAccesType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ACCORD_CLIENT"/>
+            <xs:enumeration value="SERVICE_ACCES"/>
+            <xs:enumeration value="EST_TITULAIRE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="ConsulterMesuresDetailleesV3ResponseType">
+        <xs:sequence>
+            <!-- CMDv3 avec/sans service d'accès toutes mesures -->
+            <xs:element name="pointId" type="sc:PointIdType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="mesuresCorrigees" type="sc:EtapeMetierType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="periode" type="sc:PeriodeType" minOccurs="0" maxOccurs="1"/>
+            <!-- CMDv3 avec service d'accès courbe, energie, pmax -->
+            <xs:element name="grandeur" type="sc:GrandeurInstantanees" minOccurs="0" maxOccurs="unbounded"/>
+            <!-- CMDv3 avec service d'accès index -->
+            <xs:element name="contexte" type="sc:Contexte" minOccurs="0" maxOccurs="unbounded"/>
+            <!-- CMDv3 avec service d'accès energie -->
+            <xs:element name="typeValeur" type="xs:string" minOccurs="0"/>
+            <!-- CMDv3 avec service d'accès courbe, energie, pmax -->
+            <xs:element name="modeCalcul" type="xs:string" minOccurs="0"/>
+            <!-- CMDv3 avec service d'accès energie, pmax -->
+            <xs:element name="pas" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+
+    <xs:simpleType name="EtapeMetierType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="BEST"/>
+            <xs:enumeration value="BRUT"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="PeriodeType">
+        <xs:sequence>
+            <xs:element name="dateDebut" type="xs:date"/>
+            <xs:element name="dateFin" type="xs:date"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Informations grandeur à tous les flux  -->
+    <xs:complexType name="GrandeurBase">
+        <xs:sequence>
+            <xs:element name="grandeurMetier" type="sc:GrandeurMetierType"/>
+            <xs:element name="grandeurPhysique" type="sc:GrandeurPhysiqueType"/>
+            <xs:element name="unite" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Grandeur CMDv3 avec service acces courbe, energie, pmax -->
+    <xs:complexType name="GrandeurInstantanees">
+        <xs:complexContent>
+            <xs:extension base="sc:GrandeurBase">
+                <xs:sequence>
+                    <xs:element name="points" type="sc:Points" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- Grandeur CMDv3 avec/sans service acces index-->
+    <xs:complexType name="GrandeurType">
+        <xs:complexContent>
+            <xs:extension base="sc:GrandeurBase">
+                <xs:sequence>
+                    <xs:element name="calendrier" type="sc:Calendrier" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="cadranTotalisateur" type="sc:ClasseTemporelleTotalisateur" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- Points CMDv3 avec service acces courbe, energie, pmax -->
+    <xs:complexType name="Points">
+        <xs:sequence>
+            <xs:element name="v" type="xs:string" nillable="true"/>
+            <xs:element name="d" type="xs:string"/>
+            <xs:element name="p" type="xs:string" minOccurs="0"/>
+            <xs:element name="n" type="xs:string" minOccurs="0"/>
+            <xs:element name="tc" type="xs:string" minOccurs="0"/>
+            <xs:element name="iv" type="xs:string" minOccurs="0"/>
+            <xs:element name="ec" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Mesure CMDv3 avec/sans service acces index -->
+    <xs:complexType name="Contexte">
+        <xs:sequence>
+            <xs:element name="etapeMetier" type="xs:string"/>
+            <xs:element name="contexteReleve" type="sc:ContexteReleveType"/>
+            <xs:element name="typeReleve" type="sc:TypeReleveType"/>
+            <xs:element name="motifReleve" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="grandeur" type="sc:GrandeurType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Calendrier CMDv3 avec/sans service acces index -->
+    <xs:complexType name="Calendrier">
+        <xs:sequence>
+            <xs:element name="idCalendrier" type="xs:string"/>
+            <xs:element name="libelleCalendrier" type="xs:string"/>
+            <xs:element name="classeTemporelle" type="sc:ClasseTemporelle" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Contexte relevé CMDv3 avec/sans service acces index -->
+    <xs:simpleType name="ContexteReleveType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="COL"/>
+            <xs:enumeration value="TOP"/>
+            <xs:enumeration value="FMR"/>
+            <xs:enumeration value="CRD"/>
+            <xs:enumeration value="CRI"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Type relevé CMDv3 avec/sans service acces index -->
+    <xs:simpleType name="TypeReleveType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="AP"/>
+            <xs:enumeration value="AQ"/>
+            <xs:enumeration value="AS"/>
+            <xs:enumeration value="AV"/>
+            <xs:enumeration value="LC"/>
+            <xs:enumeration value="RM"/>
+            <xs:enumeration value="RC"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Classe temporelle CMDv3 avec/sans service acces index -->
+    <xs:complexType name="ClasseTemporelle">
+        <xs:sequence>
+            <xs:element name="idClasseTemporelle" type="xs:string" minOccurs="0"/>
+            <xs:element name="libelleClasseTemporelle" type="xs:string" minOccurs="0"/>
+            <xs:element name="codeCadran" type="xs:string" minOccurs="0"/>
+            <xs:element name="valeur" type="sc:Valeur" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Classe temporelle totaliseur CMDv3 avec/sans service acces index -->
+    <xs:complexType name="ClasseTemporelleTotalisateur">
+        <xs:sequence>
+            <xs:element name="codeCadran" type="xs:string" minOccurs="0"/>
+            <xs:element name="valeur" type="sc:Valeur" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Valeur CMDv3 avec/sans service acces index -->
+    <xs:complexType name="Valeur">
+        <xs:sequence>
+            <xs:element name="d" type="xs:string"/>
+            <xs:element name="v" type="xs:integer"/>
+            <xs:element name="iv" type="sc:IvType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Valeur CMDv3 avec/sans service acces index -->
+    <xs:simpleType name="IvType">
+        <xs:restriction base="xs:integer">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Informations grandeur métier commune à tous les flux  -->
+    <xs:simpleType name="GrandeurMetierType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CONS"/>
+            <xs:enumeration value="PROD"/>
+            <xs:enumeration value="TOUT"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Informations grandeur physique commune à tous les flux  -->
+    <xs:simpleType name="GrandeurPhysiqueType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="DD"/>
+            <xs:enumeration value="PA"/>
+            <xs:enumeration value="DE"/>
+            <xs:enumeration value="DQ"/>
+            <xs:enumeration value="E"/>
+            <xs:enumeration value="EA"/>
+            <xs:enumeration value="ER"/>
+            <xs:enumeration value="ERC"/>
+            <xs:enumeration value="ERI"/>
+            <xs:enumeration value="PMA"/>
+            <xs:enumeration value="PRC"/>
+            <xs:enumeration value="PRI"/>
+            <xs:enumeration value="TF"/>
+            <xs:enumeration value="TOUT"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+</xs:schema>

--- a/lowatt_enedis/wsdl/ConsultationMesuresDetailleesV3/ADAM.ConsulterMesuresServiceReadV3.wsdl
+++ b/lowatt_enedis/wsdl/ConsultationMesuresDetailleesV3/ADAM.ConsulterMesuresServiceReadV3.wsdl
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions targetNamespace="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v3.0"
+                  xmlns:sc="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v3.0"
+                  xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:css="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common"
+                  xmlns:err="http://www.enedis.fr/sge/b2b/technique/v1.0">
+
+    <wsdl:types>
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:import schemaLocation="./ADAM.ConsulterMesuresDetailleesCommun.xsd"
+                        namespace="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common"/>
+            <xsd:import schemaLocation="./ENEDIS.Dictionnaire.Technique.v1.0.xsd"
+                        namespace="http://www.enedis.fr/sge/b2b/technique/v1.0"/>
+        </xsd:schema>
+    </wsdl:types>
+
+    <wsdl:message name="consulterMesuresDetailleesV3">
+        <wsdl:part name="parameters" element="css:consulterMesuresDetailleesV3"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="consulterMesuresDetailleesResponseV3">
+        <wsdl:part name="parameters" element="css:consulterMesuresDetailleesResponseV3"></wsdl:part>
+    </wsdl:message>
+
+    <wsdl:message name="adamB2BFault">
+        <wsdl:part name="errorB2B" element="err:erreur"/>
+    </wsdl:message>
+
+    <wsdl:portType name="AdamConsultationMesuresServiceReadPortType">
+        <wsdl:operation name="consulterMesuresDetailleesV3">
+            <wsdl:input message="sc:consulterMesuresDetailleesV3"></wsdl:input>
+            <wsdl:output message="sc:consulterMesuresDetailleesResponseV3"></wsdl:output>
+            <wsdl:fault name="fault" message="sc:adamB2BFault"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="AdamConsultationMesuresServiceReadHttpBinding"
+                  type="sc:AdamConsultationMesuresServiceReadPortType">
+        <wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="consulterMesuresDetailleesV3">
+            <wsdlsoap:operation soapAction="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v3.0"/>
+            <wsdl:input>
+                <wsdlsoap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <wsdlsoap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="AdamConsultationMesuresServiceRead">
+        <wsdl:port name="AdamConsultationMesuresServiceReadHttpPort"
+                   binding="sc:AdamConsultationMesuresServiceReadHttpBinding">
+            <wsdlsoap:address location="https://sge-b2b.enedis.fr/ConsultationMesuresDetaillees/v3.0"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>

--- a/lowatt_enedis/wsdl/ConsultationMesuresDetailleesV3/ENEDIS.Dictionnaire.Technique.v1.0.xsd
+++ b/lowatt_enedis/wsdl/ConsultationMesuresDetailleesV3/ENEDIS.Dictionnaire.Technique.v1.0.xsd
@@ -1,0 +1,98 @@
+<xs:schema targetNamespace="http://www.enedis.fr/sge/b2b/technique/v1.0" version="1.0.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0"
+           xmlns:tns="http://schemas.xmlsoap.org/soap/envelope/">
+    <xs:import namespace="http://schemas.xmlsoap.org/soap/envelope/"
+               schemaLocation="./W3C.SoapEnv.xsd"/>
+    <xs:complexType name="AcquittementType">
+        <xs:sequence>
+            <xs:element name="resultat" type="tec:ResultatType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="infoFonctionnelles" type="tec:InfoFonctionnellesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="infoDemandeur" type="tec:InfoDemandeurType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="ResultatType">
+        <xs:simpleContent>
+            <xs:extension base="tec:ResultatLibelleType">
+                <xs:attribute name="code" use="required" type="tec:ResultatCodeType"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="ErreurType">
+        <xs:sequence>
+            <xs:element name="resultat" type="tec:ResultatType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="infoFonctionnelles" type="tec:InfoFonctionnellesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="infoDemandeur" type="tec:InfoDemandeurType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="commentaire" type="tec:ErreurCommentaireType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="erreur" type="tec:ErreurType"/>
+    <xs:element name="acquittement" type="tec:AcquittementType"/>
+    <xs:complexType name="EnteteType">
+        <xs:sequence>
+            <xs:element name="version" type="tec:VersionType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="infoFonctionnelles" type="tec:InfoFonctionnellesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="infoDemandeur" type="tec:InfoDemandeurType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute use="optional" ref="tns:mustUnderstand"/>
+    </xs:complexType>
+    <xs:element name="entete" type="tec:EnteteType"/>
+    <xs:complexType name="InfoDemandeurType">
+        <xs:sequence>
+            <xs:element name="loginDemandeur" type="tec:DemandeurAdresseEmailType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="appelDemandeurId" type="tec:DemandeurAppelIdType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="referenceDemandeur" type="tec:DemandeurRefFrnType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="referenceDemandeurGroupee" type="tec:DemandeurRefFrnType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="ResultatCodeType">
+        <xs:restriction base="xs:string">
+            <xs:length value="6"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ResultatLibelleType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="VersionType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[1-9][0-9]*.[0-9]+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ErreurCommentaireType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="2047"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeurAdresseEmailType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9a-zA-Z][\-._0-9a-zA-Z]{0,255}@[0-9a-zA-Z][\-._0-9a-zA-Z]{1,255}.[a-zA-Z]{2,63}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeurRefFrnType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeurAppelIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="InfoFonctionnellesType">
+        <xs:sequence>
+            <xs:element name="pointId" type="tec:ObjetIdType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="affaireId" type="tec:ObjetIdType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="ObjetIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="20"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/lowatt_enedis/wsdl/ConsultationMesuresDetailleesV3/W3C.SoapEnv.xsd
+++ b/lowatt_enedis/wsdl/ConsultationMesuresDetailleesV3/W3C.SoapEnv.xsd
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Schema for the SOAP/1.1 envelope
+
+Portions © 2001 DevelopMentor.
+© 2001 W3C (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved.
+
+This document is governed by the W3C Software License [1] as described in the FAQ [2].
+[1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+[2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+By obtaining, using and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions:
+
+Permission to use, copy, modify, and distribute this software and its documentation, with or without modification,  for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the software and documentation or portions thereof, including modifications, that you make:
+
+1.  The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
+
+2.  Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, a short notice of the following form (hypertext is preferred, text is permitted) should be used within the body of any redistributed or derivative code: "Copyright © 2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/"
+
+3.  Notice of any changes or modifications to the W3C files, including the date changes were made. (We recommend you provide URIs to the location from which the code is derived.)
+
+Original W3C files; http://www.w3.org/2001/06/soap-envelope
+Changes made:
+     - reverted namespace to http://schemas.xmlsoap.org/soap/envelope/
+     - reverted mustUnderstand to only allow 0 and 1 as lexical values
+	 - made encodingStyle a global attribute 20020825
+	 - removed default value from mustUnderstand attribute declaration
+
+THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENTATION.
+
+The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to the software without specific, written prior permission. Title to copyright in this software and any associated documentation will at all times remain with copyright holders.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.xmlsoap.org/soap/envelope/"
+           targetNamespace="http://schemas.xmlsoap.org/soap/envelope/">
+
+
+    <!-- Envelope, header and body -->
+    <xs:element name="Envelope" type="tns:Envelope"/>
+    <xs:complexType name="Envelope">
+        <xs:sequence>
+            <xs:element ref="tns:Header" minOccurs="0"/>
+            <xs:element ref="tns:Body" minOccurs="1"/>
+            <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+
+    <xs:element name="Header" type="tns:Header"/>
+    <xs:complexType name="Header">
+        <xs:sequence>
+            <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+
+    <xs:element name="Body" type="tns:Body"/>
+    <xs:complexType name="Body">
+        <xs:sequence>
+            <xs:any namespace="##any" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>
+                    Prose in the spec does not specify that attributes are allowed on the Body element
+                </xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+
+    <!-- Global Attributes.  The following attributes are intended to be usable via qualified attribute names on any complex type referencing them.  -->
+    <xs:attribute name="mustUnderstand">
+        <xs:simpleType>
+            <xs:restriction base="xs:boolean">
+                <xs:pattern value="0|1"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="actor" type="xs:anyURI"/>
+
+    <xs:simpleType name="encodingStyle">
+        <xs:annotation>
+            <xs:documentation>
+                'encodingStyle' indicates any canonicalization conventions followed in the contents of the containing
+                element. For example, the value 'http://schemas.xmlsoap.org/soap/encoding/' indicates the pattern
+                described in SOAP specification
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:anyURI"/>
+    </xs:simpleType>
+
+    <xs:attribute name="encodingStyle" type="tns:encodingStyle"/>
+    <xs:attributeGroup name="encodingStyle">
+        <xs:attribute ref="tns:encodingStyle"/>
+    </xs:attributeGroup>
+
+    <xs:element name="Fault" type="tns:Fault"/>
+    <xs:complexType name="Fault" final="extension">
+        <xs:annotation>
+            <xs:documentation>
+                Fault reporting structure
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="faultcode" type="xs:QName"/>
+            <xs:element name="faultstring" type="xs:string"/>
+            <xs:element name="faultactor" type="xs:anyURI" minOccurs="0"/>
+            <xs:element name="detail" type="tns:detail" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="detail">
+        <xs:sequence>
+            <xs:any namespace="##any" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/test/data/requests.yaml
+++ b/test/data/requests.yaml
@@ -58,9 +58,49 @@ ADP-R1 (C5):
       </ns1:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationDonneesTechniquesContractuelles/v1.0
+ADP-R2 (C1-C4):
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consulterdonneestechniquescontractuelles/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+      <SOAP-ENV:Header>
+        <tec:entete>
+          <version>1.0</version>
+          <infoDemandeur>
+            <loginDemandeur>test@example.com</loginDemandeur>
+          </infoDemandeur>
+        </tec:entete>
+      </SOAP-ENV:Header>
+      <ns1:Body>
+        <ns0:consulterDonneesTechniquesContractuelles>
+          <pointId>98800007059999</pointId>
+          <loginUtilisateur>test@example.com</loginUtilisateur>
+          <autorisationClient>false</autorisationClient>
+        </ns0:consulterDonneesTechniquesContractuelles>
+      </ns1:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/ConsultationDonneesTechniquesContractuelles/v1.0
+ADP-R2 (C5):
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consulterdonneestechniquescontractuelles/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+      <SOAP-ENV:Header>
+        <tec:entete>
+          <version>1.0</version>
+          <infoDemandeur>
+            <loginDemandeur>test@example.com</loginDemandeur>
+          </infoDemandeur>
+        </tec:entete>
+      </SOAP-ENV:Header>
+      <ns1:Body>
+        <ns0:consulterDonneesTechniquesContractuelles>
+          <pointId>25946599093143</pointId>
+          <loginUtilisateur>test@example.com</loginUtilisateur>
+          <autorisationClient>false</autorisationClient>
+        </ns0:consulterDonneesTechniquesContractuelles>
+      </ns1:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/ConsultationDonneesTechniquesContractuelles/v1.0
 AHC-NR1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.1</version>
@@ -69,19 +109,19 @@ AHC-NR1:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:consulterMesures>
+      <ns0:Body>
+        <ns1:consulterMesures>
           <pointId>98800005782026</pointId>
           <loginDemandeur>test@example.com</loginDemandeur>
           <contratId>1234</contratId>
           <autorisationClient>false</autorisationClient>
-        </ns0:consulterMesures>
-      </ns1:Body>
+        </ns1:consulterMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesures/v1.1
 AHC-R1 (C1-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.1</version>
@@ -90,19 +130,19 @@ AHC-R1 (C1-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:consulterMesures>
+      <ns0:Body>
+        <ns1:consulterMesures>
           <pointId>98800005782026</pointId>
           <loginDemandeur>test@example.com</loginDemandeur>
           <contratId>1234</contratId>
           <autorisationClient>true</autorisationClient>
-        </ns0:consulterMesures>
-      </ns1:Body>
+        </ns1:consulterMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesures/v1.1
 AHC-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.1</version>
@@ -111,14 +151,14 @@ AHC-R1 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:consulterMesures>
+      <ns0:Body>
+        <ns1:consulterMesures>
           <pointId>25957452924301</pointId>
           <loginDemandeur>test@example.com</loginDemandeur>
           <contratId>1234</contratId>
           <autorisationClient>true</autorisationClient>
-        </ns0:consulterMesures>
-      </ns1:Body>
+        </ns1:consulterMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesures/v1.1
 ASS-R1 \*:
@@ -162,8 +202,8 @@ CMD2-NR1:
             <grandeurPhysique>PA</grandeurPhysique>
             <soutirage>true</soutirage>
             <injection>false</injection>
-            <dateDebut>2020-03-01</dateDebut>
-            <dateFin>2020-03-10</dateFin>
+            <dateDebut>2022-04-01</dateDebut>
+            <dateFin>2022-04-07</dateFin>
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>true</accordClient>
           </demande>
@@ -184,8 +224,8 @@ CMD2-NR2:
             <grandeurPhysique>EA</grandeurPhysique>
             <soutirage>true</soutirage>
             <injection>false</injection>
-            <dateDebut>2020-03-01</dateDebut>
-            <dateFin>2020-03-08</dateFin>
+            <dateDebut>2022-04-01</dateDebut>
+            <dateFin>2022-04-07</dateFin>
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>false</accordClient>
           </demande>
@@ -206,8 +246,8 @@ CMD2-R1 (C1-C4):
             <grandeurPhysique>PA</grandeurPhysique>
             <soutirage>true</soutirage>
             <injection>false</injection>
-            <dateDebut>2020-03-01</dateDebut>
-            <dateFin>2020-03-08</dateFin>
+            <dateDebut>2022-04-01</dateDebut>
+            <dateFin>2022-04-07</dateFin>
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>true</accordClient>
           </demande>
@@ -228,8 +268,8 @@ CMD2-R1 (C5):
             <grandeurPhysique>PA</grandeurPhysique>
             <soutirage>true</soutirage>
             <injection>false</injection>
-            <dateDebut>2020-03-01</dateDebut>
-            <dateFin>2020-03-08</dateFin>
+            <dateDebut>2022-04-01</dateDebut>
+            <dateFin>2022-04-07</dateFin>
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>true</accordClient>
           </demande>
@@ -250,8 +290,8 @@ CMD2-R2:
             <grandeurPhysique>PRI</grandeurPhysique>
             <soutirage>true</soutirage>
             <injection>false</injection>
-            <dateDebut>2020-03-01</dateDebut>
-            <dateFin>2020-03-08</dateFin>
+            <dateDebut>2022-04-01</dateDebut>
+            <dateFin>2022-04-07</dateFin>
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>true</accordClient>
           </demande>
@@ -272,8 +312,8 @@ CMD2-R3:
             <grandeurPhysique>EA</grandeurPhysique>
             <soutirage>true</soutirage>
             <injection>false</injection>
-            <dateDebut>2020-03-01</dateDebut>
-            <dateFin>2020-03-08</dateFin>
+            <dateDebut>2022-04-01</dateDebut>
+            <dateFin>2022-04-07</dateFin>
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>true</accordClient>
           </demande>
@@ -294,8 +334,8 @@ CMD2-R4:
             <grandeurPhysique>PMA</grandeurPhysique>
             <soutirage>true</soutirage>
             <injection>false</injection>
-            <dateDebut>2020-03-01</dateDebut>
-            <dateFin>2020-03-08</dateFin>
+            <dateDebut>2022-04-01</dateDebut>
+            <dateFin>2022-04-07</dateFin>
             <mesuresPas>P1D</mesuresPas>
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>true</accordClient>
@@ -306,7 +346,7 @@ CMD2-R4:
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v2.0
 F300B_O1 \*:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>3.0</version>
@@ -315,8 +355,8 @@ F300B_O1 \*:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderCollectePublicationMesures>
+      <ns0:Body>
+        <ns1:commanderCollectePublicationMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -342,13 +382,13 @@ F300B_O1 \*:
               <periodiciteTransmission>P1D</periodiciteTransmission>
             </accesMesures>
           </demande>
-        </ns0:commanderCollectePublicationMesures>
-      </ns1:Body>
+        </ns1:commanderCollectePublicationMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
 F300B_O2 \*:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>3.0</version>
@@ -357,8 +397,8 @@ F300B_O2 \*:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderCollectePublicationMesures>
+      <ns0:Body>
+        <ns1:commanderCollectePublicationMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -384,13 +424,13 @@ F300B_O2 \*:
               <periodiciteTransmission>P1D</periodiciteTransmission>
             </accesMesures>
           </demande>
-        </ns0:commanderCollectePublicationMesures>
-      </ns1:Body>
+        </ns1:commanderCollectePublicationMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
 F300B_O2-NR:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>3.0</version>
@@ -399,8 +439,8 @@ F300B_O2-NR:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderCollectePublicationMesures>
+      <ns0:Body>
+        <ns1:commanderCollectePublicationMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -426,13 +466,13 @@ F300B_O2-NR:
               <periodiciteTransmission>P1D</periodiciteTransmission>
             </accesMesures>
           </demande>
-        </ns0:commanderCollectePublicationMesures>
-      </ns1:Body>
+        </ns1:commanderCollectePublicationMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
 F300C_O1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>3.0</version>
@@ -441,8 +481,8 @@ F300C_O1:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderCollectePublicationMesures>
+      <ns0:Body>
+        <ns1:commanderCollectePublicationMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -468,13 +508,13 @@ F300C_O1:
               <periodiciteTransmission>P1D</periodiciteTransmission>
             </accesMesures>
           </demande>
-        </ns0:commanderCollectePublicationMesures>
-      </ns1:Body>
+        </ns1:commanderCollectePublicationMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
 F300C_O1-NR:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>3.0</version>
@@ -483,8 +523,8 @@ F300C_O1-NR:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderCollectePublicationMesures>
+      <ns0:Body>
+        <ns1:commanderCollectePublicationMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -510,13 +550,13 @@ F300C_O1-NR:
               <periodiciteTransmission>P1D</periodiciteTransmission>
             </accesMesures>
           </demande>
-        </ns0:commanderCollectePublicationMesures>
-      </ns1:Body>
+        </ns1:commanderCollectePublicationMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
 F300C_O2:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>3.0</version>
@@ -525,8 +565,8 @@ F300C_O2:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderCollectePublicationMesures>
+      <ns0:Body>
+        <ns1:commanderCollectePublicationMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -552,13 +592,13 @@ F300C_O2:
               <periodiciteTransmission>P1D</periodiciteTransmission>
             </accesMesures>
           </demande>
-        </ns0:commanderCollectePublicationMesures>
-      </ns1:Body>
+        </ns1:commanderCollectePublicationMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
 F300C_O2-NR:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>3.0</version>
@@ -567,8 +607,8 @@ F300C_O2-NR:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderCollectePublicationMesures>
+      <ns0:Body>
+        <ns1:commanderCollectePublicationMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -594,13 +634,13 @@ F300C_O2-NR:
               <periodiciteTransmission>P1D</periodiciteTransmission>
             </accesMesures>
           </demande>
-        </ns0:commanderCollectePublicationMesures>
-      </ns1:Body>
+        </ns1:commanderCollectePublicationMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
 F305:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>3.0</version>
@@ -609,8 +649,8 @@ F305:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderCollectePublicationMesures>
+      <ns0:Body>
+        <ns1:commanderCollectePublicationMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -636,13 +676,13 @@ F305:
               <periodiciteTransmission>P1D</periodiciteTransmission>
             </accesMesures>
           </demande>
-        </ns0:commanderCollectePublicationMesures>
-      </ns1:Body>
+        </ns1:commanderCollectePublicationMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
 F305-NR:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>3.0</version>
@@ -651,8 +691,8 @@ F305-NR:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderCollectePublicationMesures>
+      <ns0:Body>
+        <ns1:commanderCollectePublicationMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -678,13 +718,13 @@ F305-NR:
               <periodiciteTransmission>P1D</periodiciteTransmission>
             </accesMesures>
           </demande>
-        </ns0:commanderCollectePublicationMesures>
-      </ns1:Body>
+        </ns1:commanderCollectePublicationMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
 F305A    \*:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>3.0</version>
@@ -693,8 +733,8 @@ F305A    \*:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderCollectePublicationMesures>
+      <ns0:Body>
+        <ns1:commanderCollectePublicationMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -720,13 +760,13 @@ F305A    \*:
               <periodiciteTransmission>P1D</periodiciteTransmission>
             </accesMesures>
           </demande>
-        </ns0:commanderCollectePublicationMesures>
-      </ns1:Body>
+        </ns1:commanderCollectePublicationMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
 F305A-NR:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>3.0</version>
@@ -735,8 +775,8 @@ F305A-NR:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderCollectePublicationMesures>
+      <ns0:Body>
+        <ns1:commanderCollectePublicationMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -762,13 +802,13 @@ F305A-NR:
               <periodiciteTransmission>P1D</periodiciteTransmission>
             </accesMesures>
           </demande>
-        </ns0:commanderCollectePublicationMesures>
-      </ns1:Body>
+        </ns1:commanderCollectePublicationMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
 F305C:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandercollectepublicationmesures/v3.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>3.0</version>
@@ -777,8 +817,8 @@ F305C:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderCollectePublicationMesures>
+      <ns0:Body>
+        <ns1:commanderCollectePublicationMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -804,8 +844,8 @@ F305C:
               <periodiciteTransmission>P1D</periodiciteTransmission>
             </accesMesures>
           </demande>
-        </ns0:commanderCollectePublicationMesures>
-      </ns1:Body>
+        </ns1:commanderCollectePublicationMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
 F375A-NR1:
@@ -890,7 +930,7 @@ F375A-R1:
   url: https://sge-homologation-b2b.enedis.fr/CommandeTransmissionDonneesInfraJ/v1.0
 F380-NR1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.erdf.fr/sge/b2b/dictionnaire/v4.0/dc" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandertransmissionhistoriquemesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.erdf.fr/sge/b2b/dictionnaire/v4.0/dc" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandertransmissionhistoriquemesures/v1.0">
       <SOAP-ENV:Header>
         <dc:enteteP>
           <version>1.0</version>
@@ -902,8 +942,8 @@ F380-NR1:
           </infoDemandeur>
         </dc:enteteP>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderTransmissionHistoriqueMesures>
+      <ns0:Body>
+        <ns1:commanderTransmissionHistoriqueMesures>
           <demande>
             <donneesGenerales>
               <objetCode>HDM</objetCode>
@@ -929,13 +969,13 @@ F380-NR1:
               </pasCdc>
             </historiqueMesures>
           </demande>
-        </ns0:commanderTransmissionHistoriqueMesures>
-      </ns1:Body>
+        </ns1:commanderTransmissionHistoriqueMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeTransmissionHistoriqueMesures/v1.0
 F380-R1 (C1-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.erdf.fr/sge/b2b/dictionnaire/v4.0/dc" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandertransmissionhistoriquemesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.erdf.fr/sge/b2b/dictionnaire/v4.0/dc" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandertransmissionhistoriquemesures/v1.0">
       <SOAP-ENV:Header>
         <dc:enteteP>
           <version>1.0</version>
@@ -947,8 +987,8 @@ F380-R1 (C1-C4):
           </infoDemandeur>
         </dc:enteteP>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderTransmissionHistoriqueMesures>
+      <ns0:Body>
+        <ns1:commanderTransmissionHistoriqueMesures>
           <demande>
             <donneesGenerales>
               <objetCode>HDM</objetCode>
@@ -970,13 +1010,13 @@ F380-R1 (C1-C4):
               </pasCdc>
             </historiqueMesures>
           </demande>
-        </ns0:commanderTransmissionHistoriqueMesures>
-      </ns1:Body>
+        </ns1:commanderTransmissionHistoriqueMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeTransmissionHistoriqueMesures/v1.0
 F380-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.erdf.fr/sge/b2b/dictionnaire/v4.0/dc" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandertransmissionhistoriquemesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.erdf.fr/sge/b2b/dictionnaire/v4.0/dc" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandertransmissionhistoriquemesures/v1.0">
       <SOAP-ENV:Header>
         <dc:enteteP>
           <version>1.0</version>
@@ -988,8 +1028,8 @@ F380-R1 (C5):
           </infoDemandeur>
         </dc:enteteP>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderTransmissionHistoriqueMesures>
+      <ns0:Body>
+        <ns1:commanderTransmissionHistoriqueMesures>
           <demande>
             <donneesGenerales>
               <objetCode>HDM</objetCode>
@@ -1015,13 +1055,13 @@ F380-R1 (C5):
               </pasCdc>
             </historiqueMesures>
           </demande>
-        </ns0:commanderTransmissionHistoriqueMesures>
-      </ns1:Body>
+        </ns1:commanderTransmissionHistoriqueMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeTransmissionHistoriqueMesures/v1.0
 F385B-NR1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.erdf.fr/sge/b2b/dictionnaire/v4.0/dc" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandertransmissionhistoriquemesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.erdf.fr/sge/b2b/dictionnaire/v4.0/dc" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandertransmissionhistoriquemesures/v1.0">
       <SOAP-ENV:Header>
         <dc:enteteP>
           <version>1.0</version>
@@ -1033,8 +1073,8 @@ F385B-NR1:
           </infoDemandeur>
         </dc:enteteP>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderTransmissionHistoriqueMesures>
+      <ns0:Body>
+        <ns1:commanderTransmissionHistoriqueMesures>
           <demande>
             <donneesGenerales>
               <objetCode>HDM</objetCode>
@@ -1056,13 +1096,13 @@ F385B-NR1:
               <mesureCorrigee>false</mesureCorrigee>
             </historiqueMesures>
           </demande>
-        </ns0:commanderTransmissionHistoriqueMesures>
-      </ns1:Body>
+        </ns1:commanderTransmissionHistoriqueMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeTransmissionHistoriqueMesures/v1.0
 F385B-R1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.erdf.fr/sge/b2b/dictionnaire/v4.0/dc" xmlns:ns0="http://www.enedis.fr/sge/b2b/commandertransmissionhistoriquemesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.erdf.fr/sge/b2b/dictionnaire/v4.0/dc" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandertransmissionhistoriquemesures/v1.0">
       <SOAP-ENV:Header>
         <dc:enteteP>
           <version>1.0</version>
@@ -1074,8 +1114,8 @@ F385B-R1:
           </infoDemandeur>
         </dc:enteteP>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderTransmissionHistoriqueMesures>
+      <ns0:Body>
+        <ns1:commanderTransmissionHistoriqueMesures>
           <demande>
             <donneesGenerales>
               <objetCode>HDM</objetCode>
@@ -1097,13 +1137,13 @@ F385B-R1:
               <mesureCorrigee>false</mesureCorrigee>
             </historiqueMesures>
           </demande>
-        </ns0:commanderTransmissionHistoriqueMesures>
-      </ns1:Body>
+        </ns1:commanderTransmissionHistoriqueMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeTransmissionHistoriqueMesures/v1.0
 RP-NR1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>2.0</version>
@@ -1112,8 +1152,8 @@ RP-NR1:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherPoint>
+      <ns0:Body>
+        <ns1:rechercherPoint>
           <criteres>
             <adresseInstallation>
               <codePostal>84160</codePostal>
@@ -1123,13 +1163,13 @@ RP-NR1:
             <rechercheHorsPerimetre>false</rechercheHorsPerimetre>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherPoint>
-      </ns1:Body>
+        </ns1:rechercherPoint>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/RecherchePoint/v2.0
 RP-NR2:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>2.0</version>
@@ -1138,8 +1178,8 @@ RP-NR2:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherPoint>
+      <ns0:Body>
+        <ns1:rechercherPoint>
           <criteres>
             <adresseInstallation>
               <numeroEtNomVoie>1 RUE DE LA MER</numeroEtNomVoie>
@@ -1148,13 +1188,13 @@ RP-NR2:
             <rechercheHorsPerimetre>false</rechercheHorsPerimetre>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherPoint>
-      </ns1:Body>
+        </ns1:rechercherPoint>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/RecherchePoint/v2.0
 RP-R1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>2.0</version>
@@ -1163,8 +1203,8 @@ RP-R1:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherPoint>
+      <ns0:Body>
+        <ns1:rechercherPoint>
           <criteres>
             <adresseInstallation>
               <codePostal>34650</codePostal>
@@ -1175,13 +1215,13 @@ RP-R1:
             <rechercheHorsPerimetre>false</rechercheHorsPerimetre>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherPoint>
-      </ns1:Body>
+        </ns1:rechercherPoint>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/RecherchePoint/v2.0
 RP-R2:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>2.0</version>
@@ -1190,8 +1230,8 @@ RP-R2:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherPoint>
+      <ns0:Body>
+        <ns1:rechercherPoint>
           <criteres>
             <adresseInstallation>
               <numeroEtNomVoie>1 RUE DE LA MER</numeroEtNomVoie>
@@ -1202,13 +1242,13 @@ RP-R2:
             <rechercheHorsPerimetre>true</rechercheHorsPerimetre>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherPoint>
-      </ns1:Body>
+        </ns1:rechercherPoint>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/RecherchePoint/v2.0
 RP-R3:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>2.0</version>
@@ -1217,8 +1257,8 @@ RP-R3:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherPoint>
+      <ns0:Body>
+        <ns1:rechercherPoint>
           <criteres>
             <adresseInstallation>
               <numeroEtNomVoie>1 RUE DE LA MER</numeroEtNomVoie>
@@ -1229,8 +1269,8 @@ RP-R3:
             <rechercheHorsPerimetre>true</rechercheHorsPerimetre>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherPoint>
-      </ns1:Body>
+        </ns1:rechercherPoint>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/RecherchePoint/v2.0
 RS-R1 (C1-C4):
@@ -1255,9 +1295,9 @@ RS-R1 (C1-C4):
       </ns1:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/RechercheServicesSouscritsMesures/v1.0
-RS-R1 (C5):
+RS-R1 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/rechercherservicessouscritsmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/rechercherservicessouscritsmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -1266,14 +1306,36 @@ RS-R1 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherServicesSouscritsMesures>
+      <ns0:Body>
+        <ns1:rechercherServicesSouscritsMesures>
+          <criteres>
+            <pointId>98800000000246</pointId>
+            <contratId>1234</contratId>
+          </criteres>
+          <loginUtilisateur>test@example.com</loginUtilisateur>
+        </ns1:rechercherServicesSouscritsMesures>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/RechercheServicesSouscritsMesures/v1.0
+RS-R1 (C5):
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/rechercherservicessouscritsmesures/v1.0">
+      <SOAP-ENV:Header>
+        <tec:entete>
+          <version>1.0</version>
+          <infoDemandeur>
+            <loginDemandeur>test@example.com</loginDemandeur>
+          </infoDemandeur>
+        </tec:entete>
+      </SOAP-ENV:Header>
+      <ns0:Body>
+        <ns1:rechercherServicesSouscritsMesures>
           <criteres>
             <pointId>25884515170669</pointId>
             <contratId>1234</contratId>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherServicesSouscritsMesures>
-      </ns1:Body>
+        </ns1:rechercherServicesSouscritsMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/RechercheServicesSouscritsMesures/v1.0

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -33,7 +33,7 @@ def get_cases(_cache: Dict[None, Dict[str, str]] = {}) -> Dict[str, str]:
                 case = case.strip()
                 assert case not in cases
                 cases[case] = command
-    assert len(cases) == 40
+    assert len(cases) == 42
     _cache[None] = cases
     return cases
 


### PR DESCRIPTION
- Update instructions for the homologation process based on `Enedis.SGE.REF.0465.Homologation_Catalogue des cas de tests_Tiers_SGE23.1_v1.0.pdf`
- Add wsdl and xsd files for the new webservices
- Add decommissioning date for ConsultationMesuresDetaillees v2.0