### PR TITLE
Update homologation instructions based on SGE 23.2

### DIFF
--- a/doc/homologation.md
+++ b/doc/homologation.md
@@ -3,8 +3,8 @@ Homologation
 
 This explain how to pass through Enedis homologation process.
 
-This is based on SGE v23.1 (from `Enedis.SGE.REF.0465.Homologation_Catalogue 
-des cas de tests_Tiers_SGE23.1_v1.0.pdf`) cases.
+This is based on SGE v23.2 (from `Enedis.SGE.REF.0465.Homologation_Catalogue 
+des cas de tests_Tiers_SGE23.2_v1.0.pdf`) cases.
 
 First setup `lowatt-enedis` and then execute given commands for each services
 you want homologation and report the time the command was run to fill Enedis
@@ -40,11 +40,13 @@ ConsultationDonneesTechniquesContractuelles v1.0
 ConsultationMesures v1.1
 ------------------------
 
-| Case           | Command                                                 |
-|----------------|---------------------------------------------------------|
-| AHC-R1 (C1-C4) | `lowatt-enedis measures --autorisation 98800005782026`  |
-| AHC-R1 (C5)    | `lowatt-enedis measures --autorisation 25957452924301`  |
-| AHC-NR1        | `lowatt-enedis measures 98800005782026`                 |
+| Case              | Command                                                 |
+|-------------------|---------------------------------------------------------|
+| AHC-R1 (C1-C4) \* | `lowatt-enedis measures --autorisation 98800005782026`  |
+| AHC-R1 (C5)       | `lowatt-enedis measures --autorisation 25957452924301`  |
+| AHC-NR1           | `lowatt-enedis measures 98800005782026`                 |
+
+\* Returned "SGT4G3: Aucune mesure trouvée pour ce PRM" on the homologation environment v23.2
 
 
 ConsultationMesuresDetaillees v2.0
@@ -61,27 +63,29 @@ ConsultationMesuresDetaillees v2.0
 | CMD2-R2         | `lowatt-enedis details 30001610071843 COURBE --courbe-type PRI --from 2022-04-01 --to 2022-04-07` |
 | CMD2-R3         | `lowatt-enedis details 25478147557460 ENERGIE --from 2022-04-01 --to 2022-04-07`                  |
 | CMD2-R4         | `lowatt-enedis details 25478147557460 PMAX --from 2022-04-01 --to 2022-04-07`                     |
-| CMD2-NR1        | `lowatt-enedis details 25478147557460 COURBE --from 2022-04-01 --to 2022-04-07`                   |
+| CMD2-NR1        | `lowatt-enedis details 25478147557460 COURBE --from 2022-04-01 --to 2022-04-17`                   |
 | CMD2-NR2        | `lowatt-enedis details 25478147557460 ENERGIE --from 2022-04-01 --to 2022-04-07 --no-autorisation`|
 
 
 ConsultationMesuresDetaillees v3.0
 ----------------------------------
 
-| Case              | Command                                                                                                  |
-|-------------------|----------------------------------------------------------------------------------------------------------|
-| CMD3-R1 (C1-C4)   | `lowatt-enedis detailsV3 30001610071843 COURBE --from 2022-04-01 --to 2022-04-07`                        |
-| CMD3-R1 (C5)      | `lowatt-enedis detailsV3 25478147557460 COURBE --from 2022-04-01 --to 2022-04-07`                        |
-| CMD3-R2           | `lowatt-enedis detailsV3 30001610071843 COURBE --courbe-type PRI --from 2022-04-01 --to 2022-04-07`      |
-| CMD3-R3 (C1-C4)   | `lowatt-enedis detailsV3 30001610071843 ENERGIE --from 2022-04-01 --to 2022-04-07`                       |
-| CMD3-R3 (C5)      | `lowatt-enedis detailsV3 25478147557460 ENERGIE --from 2022-04-01 --to 2022-04-07`                       |
-| CMD3-R4           | `lowatt-enedis detailsV3 25478147557460 PMAX --from 2022-04-01 --to 2022-04-07`                          |
-| CMD3-R5 (C1-C4)   | `lowatt-enedis detailsV3 30001610071843 INDEX --from 2022-04-01 --to 2022-04-07`                         |
-| CMD3-R5 (C5)      | `lowatt-enedis detailsV3 25478147557460 INDEX --from 2022-04-01 --to 2022-04-07`                         |
-| CMD3-R6 (C1-C4)   | `lowatt-enedis detailsV3 30001610071843 INDEX --from 2022-04-01 --to 2022-04-07 --cadre SERVICE_ACCES`   |
-| CMD3-R6 (C5)      | `lowatt-enedis detailsV3 25478147557460 INDEX --from 2022-04-01 --to 2022-04-07 --cadre SERVICE_ACCES`   |
-| CMD3-NR1          | `lowatt-enedis detailsV3 25478147557460 COURBE --from 2022-04-01 --to 2022-04-08`                        |
-| CMD3-NR2          | `lowatt-enedis detailsV3 25478147557460 INDEX --from 2022-04-01 --to 2022-04-08`                         |
+| Case               | Command                                                                                                  |
+|--------------------|----------------------------------------------------------------------------------------------------------|
+| CMD3-R1 (C1-C4)    | `lowatt-enedis detailsV3 30001610071843 COURBE --from 2022-04-01 --to 2022-04-07`                        |
+| CMD3-R1 (C5)       | `lowatt-enedis detailsV3 25478147557460 COURBE --from 2022-04-01 --to 2022-04-07`                        |
+| CMD3-R2            | `lowatt-enedis detailsV3 30001610071843 COURBE --courbe-type PRI --from 2022-04-01 --to 2022-04-07`      |
+| CMD3-R3 (C1-C4) \* | `lowatt-enedis detailsV3 30001610071843 ENERGIE --from 2022-04-01 --to 2022-04-07`                       |
+| CMD3-R3 (C5)       | `lowatt-enedis detailsV3 25478147557460 ENERGIE --from 2022-04-01 --to 2022-04-07`                       |
+| CMD3-R4            | `lowatt-enedis detailsV3 25478147557460 PMAX --from 2022-04-01 --to 2022-04-07`                          |
+| CMD3-R5 (C1-C4) \* | `lowatt-enedis detailsV3 30001610071843 INDEX --from 2022-04-01 --to 2022-04-07`                         |
+| CMD3-R5 (C5) \*    | `lowatt-enedis detailsV3 25478147557460 INDEX --from 2022-04-01 --to 2022-04-07`                         |
+| CMD3-R6 (C1-C4) \* | `lowatt-enedis detailsV3 30001610071843 INDEX --from 2022-04-01 --to 2022-04-07 --cadre SERVICE_ACCES`   |
+| CMD3-R6 (C5) \*    | `lowatt-enedis detailsV3 25478147557460 INDEX --from 2022-04-01 --to 2022-04-07 --cadre SERVICE_ACCES`   |
+| CMD3-NR1           | `lowatt-enedis detailsV3 25478147557460 COURBE --from 2022-04-01 --to 2022-04-17`                        |
+| CMD3-NR2 \*        | `lowatt-enedis detailsV3 25478147557460 INDEX --from 2022-04-01 --to 2022-04-17 --cadre SERVICE_ACCES`   |
+
+\* Returned "SGT4G3: Aucune mesure trouvée pour ce PRM" on the homologation environment v23.2
 
 
 RecherchePoint v2.0
@@ -90,10 +94,12 @@ RecherchePoint v2.0
 | Case     | Command                                                                                           |
 |----------|---------------------------------------------------------------------------------------------------|
 | RP-R1    | `lowatt-enedis search --tension BTINF --categorie RES --cp 34650 --insee 34231`                   |
-| RP-R2    | `lowatt-enedis search --voie "1 RUE DE LA MER" --nom=TEST --cp 84160 --insee 84042 --hp`          |
-| RP-R3    | `lowatt-enedis search --voie "1 RUE DE LA MER" --nom=TES --cp 84160 --insee 84042 --hp`           |
+| RP-R2 \* | `lowatt-enedis search --voie "1 RUE DE LA MER" --nom=TEST --cp 84160 --insee 84042 --hp`          |
+| RP-R3 \* | `lowatt-enedis search --voie "1 RUE DE LA MER" --nom=TES --cp 84160 --insee 84042 --hp`           |
 | RP-NR1   | `lowatt-enedis search --categorie RES --cp 84160 --insee 84042`                                   |
 | RP-NR2   | `lowatt-enedis search --insee 34231 --voie "1 RUE DE LA MER"`                                     |
+
+\* Returned "None" on the homologation environment v23.2
 
 
 CommandeAccesDonneesMesures v1.0
@@ -112,10 +118,18 @@ CommandeAccesDonneesMesures v1.0
 CommandeTransmissionDonneesInfraJ v1.0
 --------------------------------------
 
-| Case      | Command                                                                                                              |
-|-----------|----------------------------------------------------------------------------------------------------------------------|
-| F375A-R1  | *XFAIL* `lowatt-enedis cmdInfraJ 98800000000246 --cdc --soutirage --denomination "Raison Sociale"`                   |
-| F375A-NR1 | *XFAIL* `lowatt-enedis cmdInfraJ 98800000000246 --idx --injection --denomination "Raison Sociale" --no-autorisation` |
+**This webservice does not work in the Homologation environment.**
+
+> Le webservice CommandeTransmissionDonneesInfraJ ne fonctionne pas dans l’environnement d’Homologation.
+> L’acteur tiers sera donc homologué sur les requêtes.
+> Il ne devra pas prêter attention aux réponses qui lui seront renvoyées via webservice.
+
+| Case         | Command                                                                                                              |
+|--------------|----------------------------------------------------------------------------------------------------------------------|
+| F375A-R1 \*  | `lowatt-enedis cmdInfraJ 98800000000246 --cdc --soutirage --denomination "Raison Sociale"`                           |
+| F375A-NR1 \* | `lowatt-enedis cmdInfraJ 98800000000246 --idx --injection --denomination "Raison Sociale" --no-autorisation`         |
+
+\* Returned "SGT500: Une erreur technique est survenue" on the homologation environment v23.2
 
 
 CommandeTransmissionHistoriqueMesures v1.0
@@ -124,13 +138,20 @@ CommandeTransmissionHistoriqueMesures v1.0
 | Case             | Command                                                                                                   |
 |------------------|-----------------------------------------------------------------------------------------------------------|
 | F380-R1 (C1-C4)  | `lowatt-enedis cmdHisto 98800005144497 CDC --pas 10`                                                      |
-| F380-R1 (C5)     | `lowatt-enedis cmdHisto 25957452924301 CDC --pas 30 --nom roro --civilite M`                              |
+| F380-R1 (C5)     | `lowatt-enedis cmdHisto 24551519514005 CDC --pas 30 --nom roro --civilite M`                              |
 | F385B-R1         | `lowatt-enedis cmdHisto 25957452924301 IDX --nom roro --civilite M`                                       |
 | F380-NR1         | `lowatt-enedis cmdHisto 25957452924301 CDC --pas 30 --nom roro --civilite M --from 2010-01-01`            |
 | F385B-NR1        | `lowatt-enedis cmdHisto 25957452924301 IDX --nom roro --civilite M --from 2010-01-01`                     |
 
+
 CommandeCollectePublicationMesures v3.0
 ---------------------------------------
+
+**This webservice does not work on the C2-C4 segment in the Homologation environment.**
+
+> Le webservice CommandeCollectePublicationMesures ne fonctionne pas sur le segment C2-C4 dans l’environnement d’Homologation.
+> L’acteur tiers sera donc homologué sur la requête pour le segment C2-C4.
+> Il ne devra pas prêter attention à la réponse qui lui sera renvoyée via webservice.
 
 | Case        | Command                                                                                                                |
 |-------------|------------------------------------------------------------------------------------------------------------------------|
@@ -147,21 +168,40 @@ CommandeCollectePublicationMesures v3.0
 | F305-NR     | `lowatt-enedis subscribe 25884515170669 --idx --denomination "COGIP" --no-autorisation`                                |
 | F305A-NR    | `lowatt-enedis subscribe 98800000000246 --idx --denomination "COGIP" --no-autorisation`                                |
 
-\* test cases for C1-C4 fail on homologation environment 22.1 (SGT500: Une erreur technique est survenue).
+\* Returned "SGT400: Une erreur fonctionnelle est survenue." on the homologation environment v23.2
+
 
 RechercherServicesSouscritsMesures v1.0
 ---------------------------------------
 
+**This webservice does not work on the C2-C4 segment in the Homologation environment.**
+
+> Le webservice RechercheServicesSouscritsMesures v1.0 ne fonctionne pas sur le segment C2-C4 dans l’environnement d’Homologation.
+> L’acteur tiers sera donc homologué sur la requête pour le segment C2-C4.
+> Il ne devra pas prêter attention à la réponse qui lui sera renvoyée via webservice.
+
 | Case          | Command                                      |
 |---------------|----------------------------------------------|
 | RS-R1 (C5)    | `lowatt-enedis subscriptions 25884515170669` |
-| RS-R1 (C2-C4) | `lowatt-enedis subscriptions 98800000000246` |
+| RS-R1 (C2-C4) \* | `lowatt-enedis subscriptions 98800000000246` |
+
+\* Returned "None" on the homologation environment v23.2
+
 
 CommandeArretServiceSouscritMesures v1.0
 ----------------------------------------
 
-| Case      | Command                                                   |
-|-----------|-----------------------------------------------------------|
-| ASS-R1 \* |  `lowatt-enedis unsubscribe 25884515170669 --id 47761068` |
+**This webservice does not work on the C2-C4 segment in the Homologation environment.**
 
-\* use an id returned by RS-R1.
+> Le webservice CommandeArretServiceSouscritMesures v1.0 ne fonctionne pas sur le segment C2-C4 dans l’environnement d’Homologation.
+> L’acteur tiers sera donc homologué sur la requête pour le segment C2-C4.
+> Il ne devra pas prêter attention à la réponse qui lui sera renvoyée via webservice.
+
+| Case                   | Command                                                  |
+|------------------------|----------------------------------------------------------|
+| ASS-R1 (C5) \*\*       | `lowatt-enedis unsubscribe 25884515170669 --id 47761068` |
+| Ass-R1 (C2-C4) \* \*\* | `lowatt-enedis unsubscribe 98800000000246 --id 47761068` |
+
+\* Returned "SGT500: Une erreur technique est survenue" on the homologation environment v23.2
+
+\*\* Use an id returned by RS-R1.

--- a/test/data/requests.yaml
+++ b/test/data/requests.yaml
@@ -119,7 +119,7 @@ AHC-NR1:
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesures/v1.1
-AHC-R1 (C1-C4):
+AHC-R1 (C1-C4) \*:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1">
       <SOAP-ENV:Header>
@@ -161,7 +161,7 @@ AHC-R1 (C5):
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesures/v1.1
-ASS-R1 \*:
+ASS-R1 (C5) \*\*:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderarretservicesouscritmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
       <SOAP-ENV:Header>
@@ -189,12 +189,40 @@ ASS-R1 \*:
       </ns1:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeArretServiceSouscritMesures/v1.0
+Ass-R1 (C2-C4) \* \*\*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderarretservicesouscritmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+      <SOAP-ENV:Header>
+        <tec:entete>
+          <version>1.0</version>
+          <infoDemandeur>
+            <loginDemandeur>test@example.com</loginDemandeur>
+          </infoDemandeur>
+        </tec:entete>
+      </SOAP-ENV:Header>
+      <ns1:Body>
+        <ns0:commanderArretServiceSouscritMesures>
+          <demande>
+            <donneesGenerales>
+              <objetCode>ASS</objetCode>
+              <pointId>98800000000246</pointId>
+              <initiateurLogin>test@example.com</initiateurLogin>
+              <contratId>1234</contratId>
+            </donneesGenerales>
+            <arretServiceSouscrit>
+              <serviceSouscritId>47761068</serviceSouscritId>
+            </arretServiceSouscrit>
+          </demande>
+        </ns0:commanderArretServiceSouscritMesures>
+      </ns1:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeArretServiceSouscritMesures/v1.0
 CMD2-NR1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetaillees>
+      <ns0:Body>
+        <ns1:consulterMesuresDetaillees>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>25478147557460</pointId>
@@ -203,20 +231,20 @@ CMD2-NR1:
             <soutirage>true</soutirage>
             <injection>false</injection>
             <dateDebut>2022-04-01</dateDebut>
-            <dateFin>2022-04-07</dateFin>
+            <dateFin>2022-04-17</dateFin>
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>true</accordClient>
           </demande>
-        </ns0:consulterMesuresDetaillees>
-      </ns1:Body>
+        </ns1:consulterMesuresDetaillees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v2.0
 CMD2-NR2:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetaillees>
+      <ns0:Body>
+        <ns1:consulterMesuresDetaillees>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>25478147557460</pointId>
@@ -229,16 +257,16 @@ CMD2-NR2:
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>false</accordClient>
           </demande>
-        </ns0:consulterMesuresDetaillees>
-      </ns1:Body>
+        </ns1:consulterMesuresDetaillees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v2.0
 CMD2-R1 (C1-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetaillees>
+      <ns0:Body>
+        <ns1:consulterMesuresDetaillees>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>30001610071843</pointId>
@@ -251,16 +279,16 @@ CMD2-R1 (C1-C4):
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>true</accordClient>
           </demande>
-        </ns0:consulterMesuresDetaillees>
-      </ns1:Body>
+        </ns1:consulterMesuresDetaillees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v2.0
 CMD2-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetaillees>
+      <ns0:Body>
+        <ns1:consulterMesuresDetaillees>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>25478147557460</pointId>
@@ -273,16 +301,16 @@ CMD2-R1 (C5):
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>true</accordClient>
           </demande>
-        </ns0:consulterMesuresDetaillees>
-      </ns1:Body>
+        </ns1:consulterMesuresDetaillees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v2.0
 CMD2-R2:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetaillees>
+      <ns0:Body>
+        <ns1:consulterMesuresDetaillees>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>30001610071843</pointId>
@@ -295,16 +323,16 @@ CMD2-R2:
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>true</accordClient>
           </demande>
-        </ns0:consulterMesuresDetaillees>
-      </ns1:Body>
+        </ns1:consulterMesuresDetaillees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v2.0
 CMD2-R3:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetaillees>
+      <ns0:Body>
+        <ns1:consulterMesuresDetaillees>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>25478147557460</pointId>
@@ -317,16 +345,16 @@ CMD2-R3:
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>true</accordClient>
           </demande>
-        </ns0:consulterMesuresDetaillees>
-      </ns1:Body>
+        </ns1:consulterMesuresDetaillees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v2.0
 CMD2-R4:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/v2.0">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetaillees>
+      <ns0:Body>
+        <ns1:consulterMesuresDetaillees>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>25478147557460</pointId>
@@ -340,8 +368,8 @@ CMD2-R4:
             <mesuresCorrigees>false</mesuresCorrigees>
             <accordClient>true</accordClient>
           </demande>
-        </ns0:consulterMesuresDetaillees>
-      </ns1:Body>
+        </ns1:consulterMesuresDetaillees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v2.0
 CMD3-NR1:
@@ -356,7 +384,7 @@ CMD3-NR1:
             <mesuresTypeCode>COURBE</mesuresTypeCode>
             <grandeurPhysique>PA</grandeurPhysique>
             <dateDebut>2022-04-01</dateDebut>
-            <dateFin>2022-04-08</dateFin>
+            <dateFin>2022-04-17</dateFin>
             <mesuresCorrigees>false</mesuresCorrigees>
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
@@ -365,7 +393,7 @@ CMD3-NR1:
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v3.0
-CMD3-NR2:
+CMD3-NR2 \*:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
@@ -377,10 +405,10 @@ CMD3-NR2:
             <mesuresTypeCode>INDEX</mesuresTypeCode>
             <grandeurPhysique>EA</grandeurPhysique>
             <dateDebut>2022-04-01</dateDebut>
-            <dateFin>2022-04-08</dateFin>
+            <dateFin>2022-04-17</dateFin>
             <mesuresCorrigees>false</mesuresCorrigees>
             <sens>SOUTIRAGE</sens>
-            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+            <cadreAcces>SERVICE_ACCES</cadreAcces>
           </demande>
         </ns1:consulterMesuresDetailleesV3>
       </ns0:Body>
@@ -449,7 +477,7 @@ CMD3-R2:
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v3.0
-CMD3-R3 (C1-C4):
+CMD3-R3 (C1-C4) \*:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
@@ -513,7 +541,7 @@ CMD3-R4:
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v3.0
-CMD3-R5 (C1-C4):
+CMD3-R5 (C1-C4) \*:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
@@ -534,7 +562,7 @@ CMD3-R5 (C1-C4):
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v3.0
-CMD3-R5 (C5):
+CMD3-R5 (C5) \*:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
@@ -555,7 +583,7 @@ CMD3-R5 (C5):
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v3.0
-CMD3-R6 (C1-C4):
+CMD3-R6 (C1-C4) \*:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
@@ -576,7 +604,7 @@ CMD3-R6 (C1-C4):
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesuresDetaillees/v3.0
-CMD3-R6 (C5):
+CMD3-R6 (C5) \*:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
@@ -1101,7 +1129,7 @@ F305C:
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeCollectePublicationMesures/v3.0
-F375A-NR1:
+F375A-NR1 \*:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandertransmissiondonneesinfraj/v1.0">
       <SOAP-ENV:Header>
@@ -1141,7 +1169,7 @@ F375A-NR1:
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeTransmissionDonneesInfraJ/v1.0
-F375A-R1:
+F375A-R1 \*:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commandertransmissiondonneesinfraj/v1.0">
       <SOAP-ENV:Header>
@@ -1274,7 +1302,7 @@ F380-R1 (C5):
         <dc:enteteP>
           <version>1.0</version>
           <infoFonctionnelles>
-            <pointId>25957452924301</pointId>
+            <pointId>24551519514005</pointId>
           </infoFonctionnelles>
           <infoDemandeur>
             <loginDemandeur>test@example.com</loginDemandeur>
@@ -1287,7 +1315,7 @@ F380-R1 (C5):
             <donneesGenerales>
               <objetCode>HDM</objetCode>
               <contratId>1234</contratId>
-              <pointId>25957452924301</pointId>
+              <pointId>24551519514005</pointId>
               <initiateurLogin>test@example.com</initiateurLogin>
             </donneesGenerales>
             <historiqueMesures>
@@ -1472,7 +1500,7 @@ RP-R1:
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/RecherchePoint/v2.0
-RP-R2:
+RP-R2 \*:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">
       <SOAP-ENV:Header>
@@ -1499,7 +1527,7 @@ RP-R2:
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/RecherchePoint/v2.0
-RP-R3:
+RP-R3 \*:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">
       <SOAP-ENV:Header>
@@ -1526,9 +1554,9 @@ RP-R3:
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/RecherchePoint/v2.0
-RS-R1 (C1-C4):
+RS-R1 (C2-C4) \*:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/rechercherservicessouscritsmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/rechercherservicessouscritsmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -1537,42 +1565,20 @@ RS-R1 (C1-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherServicesSouscritsMesures>
+      <ns0:Body>
+        <ns1:rechercherServicesSouscritsMesures>
           <criteres>
             <pointId>98800000000246</pointId>
             <contratId>1234</contratId>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherServicesSouscritsMesures>
-      </ns1:Body>
-    </SOAP-ENV:Envelope>
-  url: https://sge-homologation-b2b.enedis.fr/RechercheServicesSouscritsMesures/v1.0
-RS-R1 (C2-C4):
-  data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/rechercherservicessouscritsmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
-      <SOAP-ENV:Header>
-        <tec:entete>
-          <version>1.0</version>
-          <infoDemandeur>
-            <loginDemandeur>test@example.com</loginDemandeur>
-          </infoDemandeur>
-        </tec:entete>
-      </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherServicesSouscritsMesures>
-          <criteres>
-            <pointId>98800000000246</pointId>
-            <contratId>1234</contratId>
-          </criteres>
-          <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherServicesSouscritsMesures>
-      </ns1:Body>
+        </ns1:rechercherServicesSouscritsMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/RechercheServicesSouscritsMesures/v1.0
 RS-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/rechercherservicessouscritsmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/rechercherservicessouscritsmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -1581,14 +1587,14 @@ RS-R1 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherServicesSouscritsMesures>
+      <ns0:Body>
+        <ns1:rechercherServicesSouscritsMesures>
           <criteres>
             <pointId>25884515170669</pointId>
             <contratId>1234</contratId>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherServicesSouscritsMesures>
-      </ns1:Body>
+        </ns1:rechercherServicesSouscritsMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/RechercheServicesSouscritsMesures/v1.0

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -33,7 +33,7 @@ def get_cases(_cache: dict[None, dict[str, str]] = {}) -> dict[str, str]:
                 case = case.strip()
                 assert case not in cases
                 cases[case] = command
-    assert len(cases) == 54
+    assert len(cases) == 55
     _cache[None] = cases
     return cases
 


### PR DESCRIPTION
Update homologation instructions based on SGE 23.2

- F380-R1 : Update the PCE for the C5 segment
- CMD2-NR1, CMD3-NR1 and CMD3-NR2 : Set 2022-04-17 for the end date, to be sure to exceed the 7 days limit
- ASS-R1 : Add a command for the C2-C4 segment
- Add a comment when returned values are incorrect
- Add a warning when a webservice officialy doesn't work (either completely or for a specific segment)