### PR TITLE
Issue 27 format json errors use unformated on stderr

### DIFF
--- a/lowatt_enedis/__main__.py
+++ b/lowatt_enedis/__main__.py
@@ -24,6 +24,7 @@ import lowatt_enedis.services  # noqa: register services
 from lowatt_enedis import (
     COMMAND_SERVICE,
     WSException,
+    WSFaultException,
     handle_cli_command,
     init_cli,
     wsdl,
@@ -65,7 +66,7 @@ def run() -> NoReturn:
     elif args.command:
         try:
             handle_cli_command(args.command, args)
-        except WSException as exc:
+        except (WSException, WSFaultException) as exc:
             print(exc)  # noqa
             sys.exit(1)
 


### PR DESCRIPTION
resolves #27 

error detection could not be set in exit code (SGT*** errors might have alphabetic characters in ***)
XML log (describing the request) from stubs.client has been moved to stderr
only final result should be logged to stdout
error return value has only been modified for JSON (handling other formats should be easy enough to add)