### PR TITLE
Implement M023

### DIFF
--- a/doc/homologation.md
+++ b/doc/homologation.md
@@ -214,3 +214,51 @@ CommandeArretServiceSouscritMesures v1.0
 \* Returned "SGT500: Une erreur technique est survenue" on the homologation environment v23.2
 
 \*\* Use an id returned by RS-R1.
+
+CommandeHistoriqueDonneesMesuresFines v1.0
+------------------------------------------
+
+**This webservice does not work in the Homologation environment.**
+
+| Case                   | Command                                                                                                                           |
+|------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| MFI-GK-R1 (C5) \*      | `lowatt-enedis cmdHistoFine 25150217034354,25825036170379,25999131613803,50086054270348,25262662681289 ENERGIE`                   |
+| MFI-GK-R1 (C2-C4) \*   | `lowatt-enedis cmdHistoFine 98800004935121,98800001544168,98800004938924,98800006694381,98800001220186 ENERGIE`                   |
+| MFI-GK-R2 (C5) \*      | `lowatt-enedis cmdHistoFine 25150217034354 COURBES`                                                                               |
+| MFI-GK-R2 (C2-C4) \*   | `lowatt-enedis cmdHistoFine 98800004935121 COURBES`                                                                               |
+| MFI-GK-R3 (C5) \*      | `lowatt-enedis cmdHistoFine 25150217034354 PMAX`                                                                                  |
+| MFI-GK-R3 (C2-C4) \*   | `lowatt-enedis cmdHistoFine 98800004935121 PMAX`                                                                                  |
+| MFI-GK-R4 (C5) \*      | `lowatt-enedis cmdHistoFine 25150217034354,25825036170379,25999131613803,50086054270348,25262662681289 INDEX`                     |
+| MFI-GK-R4 (C2-C4) \*   | `lowatt-enedis cmdHistoFine 98800004935121,98800001544168,98800004938924,98800006694381,98800001220186 INDEX`                     |
+| MFI-GK-NR1 (C5) \*     | `lowatt-enedis cmdHistoFine 25150217034354,25825036170379,25999131613803,50086054270348,25262662681289 COURBES --from 2020-01-01` |
+| MFI-GK-NR1 (C2-C4) \*  | `lowatt-enedis cmdHistoFine 98800004935121,98800001544168,98800004938924,98800006694381,98800001220186 COURBES`                   |
+| MFI-GK-NR2 (C5) \*     | `lowatt-enedis cmdHistoFine 25150217034354,25825036170379,25999131613803,50086054270348,25262662681289 INDEX --from 2020-01-01`   |
+| MFI-GK-NR2 (C2-C4) \*  | `lowatt-enedis cmdHistoFine 98800004935121,98800001544168,98800004938924,98800006694381,98800001220186 INDEX`                     |
+
+\* Returned "Erreur Technique MFI v23.4
+
+CommandeHistoriqueDonneesMesuresFacturantes v1.0
+------------------------------------------------
+
+**This webservice does not work in the Homologation environment.**
+
+| Case                   | Command                                                                                                                                   |
+|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| MFA-GK-R1 (C5) \*      | `lowatt-enedis cmdHistoFact 25150217034354,25825036170379,25999131613803,50086054270348,25262662681289`                                   |
+| MFA-GK-R1 (C2-C4) \*   | `lowatt-enedis cmdHistoFact 98800004935121,98800001544168,98800004938924,98800006694381,98800001220186`                                   |
+| MFA-GK-NR1 (C5) \*     | `lowatt-enedis cmdHistoFact 25150217034354,25825036170379,25999131613803,50086054270348,25262662681289 --from 2023-10-01 --to 2023-08-01` |
+| MFA-GK-NR1 (C2-C4) \*  | `lowatt-enedis cmdHistoFact 98800004935121,98800001544168,98800004938924,98800006694381,98800001220186  --from 2023-10-01 --to 2023-08-01`|
+
+\* Returned "Erreur Technique MFA v23.4
+
+CommandeInformationsTechniquesEtContractuelles v1.0
+---------------------------------------------------
+
+**This webservice does not work in the Homologation environment.**
+
+| Case                   | Command                                                                                                 |
+|------------------------|---------------------------------------------------------------------------------------------------------|
+| ITC-GK-R1 (C5) \*      | `lowatt-enedis cmdTechnical 25150217034354,25825036170379,25999131613803,50086054270348,25262662681289` |
+| ITC-GK-R1 (C2-C4) \*   | `lowatt-enedis cmdTechnical 98800004935121,98800001544168,98800004938924,98800006694381,98800001220186` |
+
+\* Returned "Erreur Technique ITC v23.4

--- a/lowatt_enedis/__init__.py
+++ b/lowatt_enedis/__init__.py
@@ -133,7 +133,7 @@ class WSException(Exception):
     """
 
     def __init__(self, exc: WebFault):
-        self.exc = exc
+        self.web_fault = exc
         fault = exc.fault
         try:
             res = fault.detail.erreur.resultat
@@ -163,7 +163,8 @@ def handle_cli_command(command: str, args: argparse.Namespace) -> None:
         obj = handler(client, args)
     except WSException as exc:
         if args.output == "xml":
-            print(client.last_received().str())  # noqa: T201
+            # client.last_received() is None in case of WebFault
+            print(exc.web_fault.document.str())  # noqa: T201
         elif args.output == "json":
             json.dump(
                 {"errcode": exc.code, "errmsg": exc.message},

--- a/lowatt_enedis/__init__.py
+++ b/lowatt_enedis/__init__.py
@@ -136,16 +136,18 @@ class WSException(Exception):
         self.exc = exc
         fault = exc.fault
         try:
-            detail = fault.detail
+            res = fault.detail.erreur.resultat
+            self.message = str(res.value)
+            self.code: Optional[str] = str(res._code)
         except AttributeError:
-            # AttributeError: 'Fault' object has no attribute 'detail',
-            # at least when server's response isn't properly parseable.
-            self.code = None
-            self.message = str(exc)
-        else:
-            res = detail.erreur.resultat
-            self.code = res._code
-            self.message = res.value
+            if "faultcode" in fault and "faultstring" in fault:
+                self.code = str(fault.faultcode)
+                self.message = str(fault.faultstring)
+            else:
+                # Unable to find message in 'Fault' object,
+                # at least when server's response isn't properly parseable.
+                self.code = None
+                self.message = str(exc)
 
     def __str__(self) -> str:
         if self.code:

--- a/lowatt_enedis/services.py
+++ b/lowatt_enedis/services.py
@@ -410,7 +410,7 @@ def measures_resp2py(resp: suds.sudsobject.Object) -> Iterator[dict[str, Any]]:
         MESURES_OPTIONS,
     ),
 )
-@ws("ConsultationMesuresDetaillees-v2.0", header_ns_prefix="ns2")
+@ws("ConsultationMesuresDetaillees-v2.0")
 def point_detailed_measures(
     client: Client, args: argparse.Namespace
 ) -> suds.sudsobject.Object:
@@ -493,7 +493,7 @@ def point_detailed_measures(
         MESURES_OPTIONS,
     ),
 )
-@ws("ConsultationMesuresDetaillees-v3.0", header_ns_prefix="ns2")
+@ws("ConsultationMesuresDetaillees-v3.0")
 def point_detailed_measuresV3(
     client: Client, args: argparse.Namespace
 ) -> suds.sudsobject.Object:
@@ -606,12 +606,11 @@ DONNEES_GENERALES_OPTIONS = dict_from_dicts(
         },
     ),
 )
-@ws("CommandeTransmissionHistoriqueMesures-v1.0", header_ns_prefix="ns1")
+@ws("CommandeTransmissionHistoriqueMesures-v1.0")
 def point_cmd_histo(client: Client, args: argparse.Namespace) -> suds.sudsobject.Object:
     _check_mesure_options_consistency(args)
 
     header = client.options.soapheaders
-    header.infoFonctionnelles = client.factory.create("ns1:infoFonctionnelles")
     header.infoFonctionnelles.pointId = get_option(args, "prm")
     del header.infoFonctionnelles.affaireId
 

--- a/lowatt_enedis/wsdl/M023_v1.2.0/Services/CommandeHistoriqueDonneesMesuresFacturantes/B2B_M023MFA.wsdl
+++ b/lowatt_enedis/wsdl/M023_v1.2.0/Services/CommandeHistoriqueDonneesMesuresFacturantes/B2B_M023MFA.wsdl
@@ -1,0 +1,55 @@
+<wsdl:definitions targetNamespace="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1"
+                  xmlns:err="http://www.enedis.fr/sge/b2b/technique/v1.0">
+    <!-- Types -->
+    <wsdl:types>
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:import namespace="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1"
+                        schemaLocation="../../xsd/m023/MesuresFacturantesModel.xsd"/>
+            <xsd:import namespace="http://www.enedis.fr/sge/b2b/technique/v1.0"
+                        schemaLocation="../../xsd/transverse/ENEDIS.Dictionnaire.Technique.v1.0.xsd"/>
+        </xsd:schema>
+    </wsdl:types>
+
+    <!-- Messages -->
+    <wsdl:message name="demandePublicationMesuresFacturantes">
+        <wsdl:part name="demandePublicationMesuresFacturantes" element="tns:demandePublicationMesuresFacturantes"/>
+    </wsdl:message>
+    <wsdl:message name="affaireId">
+        <wsdl:part name="affaireId" element="tns:affaireId"/>
+    </wsdl:message>
+    <wsdl:message name="adamB2BFault">
+        <wsdl:part name="errorB2B" element="err:erreur"/>
+    </wsdl:message>
+
+    <!-- PortType -->
+    <wsdl:portType name="AdamCommandeHistoriqueDonneesMesuresFacturantesPort">
+        <wsdl:operation name="commandeHistoriqueDonneesMesuresFacturantes">
+            <wsdl:input name="demandePublicationMesuresFacturantes" message="tns:demandePublicationMesuresFacturantes"/>
+            <wsdl:output name="affaireId" message="tns:affaireId"/>
+            <wsdl:fault name="fault" message="tns:adamB2BFault"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <!-- Binding -->
+    <wsdl:binding name="AdamCommandeHistoriqueDonneesMesuresFacturantesBinding" type="tns:AdamCommandeHistoriqueDonneesMesuresFacturantesPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="commandeHistoriqueDonneesMesuresFacturantes">
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="AdamCommandeHistoriqueDonneesMesuresFacturantesService">
+        <wsdl:port name="AdamCommandeHistoriqueDonneesMesuresFacturantesPort" binding="tns:AdamCommandeHistoriqueDonneesMesuresFacturantesBinding">
+            <soap:address location="https://sge-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFacturantes/v1.0"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/lowatt_enedis/wsdl/M023_v1.2.0/Services/CommandeHistoriqueDonneesMesuresFines/B2B_M023MFI.wsdl
+++ b/lowatt_enedis/wsdl/M023_v1.2.0/Services/CommandeHistoriqueDonneesMesuresFines/B2B_M023MFI.wsdl
@@ -1,0 +1,55 @@
+<wsdl:definitions targetNamespace="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1"
+                  xmlns:err="http://www.enedis.fr/sge/b2b/technique/v1.0">
+    <!-- Types -->
+    <wsdl:types>
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:import namespace="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1"
+                        schemaLocation="../../xsd/m023/MesuresFinesModel.xsd"/>
+            <xsd:import namespace="http://www.enedis.fr/sge/b2b/technique/v1.0"
+                        schemaLocation="../../xsd/transverse/ENEDIS.Dictionnaire.Technique.v1.0.xsd"/>
+        </xsd:schema>
+    </wsdl:types>
+
+    <!-- Messages -->
+    <wsdl:message name="demandePublicationMesuresFines">
+        <wsdl:part name="demandePublicationMesuresFines" element="tns:demandePublicationMesuresFines"/>
+    </wsdl:message>
+    <wsdl:message name="affaireId">
+        <wsdl:part name="affaireId" element="tns:affaireId"/>
+    </wsdl:message>
+    <wsdl:message name="adamB2BFault">
+        <wsdl:part name="errorB2B" element="err:erreur"/>
+    </wsdl:message>
+
+    <!-- PortType -->
+    <wsdl:portType name="AdamCommandeHistoriqueDonneesMesuresFinesPort">
+        <wsdl:operation name="commandeHistoriqueDonneesMesuresFines">
+            <wsdl:input name="demandePublicationMesuresFines" message="tns:demandePublicationMesuresFines"/>
+            <wsdl:output name="affaireId" message="tns:affaireId"/>
+            <wsdl:fault name="fault" message="tns:adamB2BFault"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <!-- Binding -->
+    <wsdl:binding name="AdamCommandeHistoriqueDonneesMesuresFinesBinding" type="tns:AdamCommandeHistoriqueDonneesMesuresFinesPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="commandeHistoriqueDonneesMesuresFines">
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="AdamCommandeHistoriqueDonneesMesuresFinesService">
+        <wsdl:port name="AdamCommandeHistoriqueDonneesMesuresFinesPort" binding="tns:AdamCommandeHistoriqueDonneesMesuresFinesBinding">
+            <soap:address location="https://sge-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/lowatt_enedis/wsdl/M023_v1.2.0/Services/CommandeInformationsTechniquesEtContractuelles/B2B_M023ITC.wsdl
+++ b/lowatt_enedis/wsdl/M023_v1.2.0/Services/CommandeInformationsTechniquesEtContractuelles/B2B_M023ITC.wsdl
@@ -1,0 +1,56 @@
+<wsdl:definitions targetNamespace="https://sge-b2b.enedis.fr/services/commandeinformationstechniquesetcontractuelles/v1"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="https://sge-b2b.enedis.fr/services/commandeinformationstechniquesetcontractuelles/v1"
+                  xmlns:err="http://www.enedis.fr/sge/b2b/technique/v1.0">
+    <!-- Types -->
+    <wsdl:types>
+		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:import namespace="https://sge-b2b.enedis.fr/services/commandeinformationstechniquesetcontractuelles/v1"
+                        schemaLocation="../../xsd/m023/ITCModel.xsd"/>
+            <xsd:import namespace="http://www.enedis.fr/sge/b2b/technique/v1.0"
+                        schemaLocation="../../xsd/transverse/ENEDIS.Dictionnaire.Technique.v1.0.xsd"/>
+        </xsd:schema>
+    </wsdl:types>
+
+    <!-- Messages -->
+    <wsdl:message name="demandePublicationITC">
+        <wsdl:part name="demandePublicationITC" element="tns:demandePublicationITC"/>
+    </wsdl:message>
+    <wsdl:message name="affaireId">
+        <wsdl:part name="affaireId" element="tns:affaireId"/>
+    </wsdl:message>
+    <wsdl:message name="adamB2BFault">
+        <wsdl:part name="errorB2B" element="err:erreur"/>
+    </wsdl:message>
+
+    <!-- PortType -->
+    <wsdl:portType name="AdamCommandeInformationsTechniquesEtContractuellesPort">
+        <wsdl:operation name="commandeInformationsTechniquesEtContractuelles">
+            <wsdl:input name="demandePublicationITC" message="tns:demandePublicationITC"/>
+            <wsdl:output name="affaireId" message="tns:affaireId"/>
+            <wsdl:fault name="fault" message="tns:adamB2BFault"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <!-- Binding -->
+    <wsdl:binding name="AdamCommandeInformationsTechniquesEtContractuellesBinding" type="tns:AdamCommandeInformationsTechniquesEtContractuellesPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="commandeInformationsTechniquesEtContractuelles">
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <!-- Service -->
+    <wsdl:service name="AdamCommandeInformationsTechniquesEtContractuellesService">
+        <wsdl:port name="AdamCommandeInformationsTechniquesEtContractuellesPort" binding="tns:AdamCommandeInformationsTechniquesEtContractuellesBinding">
+            <soap:address location="https://sge-b2b.enedis.fr/CommandeInformationsTechniquesEtContractuelles/v1.0"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/lowatt_enedis/wsdl/M023_v1.2.0/xsd/m023/ITCModel.xsd
+++ b/lowatt_enedis/wsdl/M023_v1.2.0/xsd/m023/ITCModel.xsd
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:sc="https://sge-b2b.enedis.fr/services/commandeinformationstechniquesetcontractuelles/v1"
+            targetNamespace="https://sge-b2b.enedis.fr/services/commandeinformationstechniquesetcontractuelles/v1">
+
+    <xs:element name="affaireId" type="sc:affaireId"/>
+    <xs:element name="demandePublicationITC" type="sc:demandePublicationITC"/>
+
+    <!-- affaireId Reponse du webservice -->
+    <xs:simpleType name="affaireId">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="8"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- demandePublicationITC Requete du webservice -->
+    <xs:complexType name="demandePublicationITC">
+        <xs:sequence>
+            <xs:element name="donneesGenerales" type="sc:donneesGenerales"/>
+            <xs:element name="demande" type="sc:demande"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Données Générales -->
+    <xs:simpleType name="initiateurLogin">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="contratId">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="referenceDemandeur">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="referenceRegroupement">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="affaireReference">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="8"/>
+            <xs:maxLength value="8"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="donneesGenerales">
+        <xs:sequence>
+            <xs:element name="initiateurLogin" type="sc:initiateurLogin"/>
+            <xs:element name="contratId" type="sc:contratId"/>
+            <xs:element name="referenceDemandeur" type="sc:referenceDemandeur" minOccurs="0"/>
+            <xs:element name="affaireReference" type="sc:affaireReference" minOccurs="0"/>
+            <xs:element name="referenceRegroupement" type="sc:referenceRegroupement" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- demande -->
+    <xs:simpleType name="format">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="JSON"/>
+            <xs:enumeration value="CSV"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="pointId">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{14}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="sens">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="SOUTIRAGE"/>
+            <xs:enumeration value="INJECTION"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cadreAcces">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="SERVICE_ACCES"/>
+            <xs:enumeration value="EST_TITULAIRE"/>
+            <xs:enumeration value="ACCORD_CLIENT"/>
+        </xs:restriction>
+    </xs:simpleType>
+	
+	<xs:complexType name="pointIds">
+        <xs:sequence>
+            <xs:element name="pointId" type="sc:pointId" minOccurs="1" maxOccurs="10000"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="demande">
+        <xs:sequence>
+            <xs:element name="format" type="sc:format" minOccurs="0"/>
+            <xs:element name="pointIds" type="sc:pointIds" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="sens" type="sc:sens"/>
+            <xs:element name="cadreAcces" type="sc:cadreAcces"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/lowatt_enedis/wsdl/M023_v1.2.0/xsd/m023/MesuresFacturantesModel.xsd
+++ b/lowatt_enedis/wsdl/M023_v1.2.0/xsd/m023/MesuresFacturantesModel.xsd
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:sc="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1"
+            targetNamespace="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1">
+
+    <xs:element name="affaireId" type="sc:affaireId"/>
+    <xs:element name="demandePublicationMesuresFacturantes" type="sc:demandePublicationMesuresFacturantes"/>
+
+    <!-- affaireId Reponse du webservice -->
+    <xs:simpleType name="affaireId">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="8"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- demandePublicationMesuresFacturantes Requete du webservice -->
+    <xs:complexType name="demandePublicationMesuresFacturantes">
+        <xs:sequence>
+            <xs:element name="donneesGenerales" type="sc:donneesGenerales"/>
+            <xs:element name="demande" type="sc:demande"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Données Générales -->
+    <xs:simpleType name="initiateurLogin">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="contratId">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="referenceDemandeur">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="referenceRegroupement">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="affaireReference">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="8"/>
+            <xs:maxLength value="8"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="donneesGenerales">
+        <xs:sequence>
+            <xs:element name="initiateurLogin" type="sc:initiateurLogin"/>
+            <xs:element name="contratId" type="sc:contratId"/>
+            <xs:element name="referenceDemandeur" type="sc:referenceDemandeur" minOccurs="0"/>
+            <xs:element name="affaireReference" type="sc:affaireReference" minOccurs="0"/>
+            <xs:element name="referenceRegroupement" type="sc:referenceRegroupement" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- demande -->
+    <xs:simpleType name="format">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="JSON"/>
+            <xs:enumeration value="CSV"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="pointId">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{14}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="dateDebut">
+        <xs:restriction base="xs:date"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="dateFin">
+        <xs:restriction base="xs:date"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="sens">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="SOUTIRAGE"/>
+            <xs:enumeration value="INJECTION"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cadreAcces">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="SERVICE_ACCES"/>
+            <xs:enumeration value="EST_TITULAIRE"/>
+            <xs:enumeration value="ACCORD_CLIENT"/>
+        </xs:restriction>
+    </xs:simpleType>
+	
+	<xs:complexType name="pointIds">
+        <xs:sequence>
+            <xs:element name="pointId" type="sc:pointId" minOccurs="1" maxOccurs="10000"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="demande">
+        <xs:sequence>
+            <xs:element name="format" type="sc:format" minOccurs="0"/>
+            <xs:element name="pointIds" type="sc:pointIds" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="dateDebut" type="sc:dateDebut"/>
+            <xs:element name="dateFin" type="sc:dateFin"/>
+            <xs:element name="sens" type="sc:sens"/>
+            <xs:element name="cadreAcces" type="sc:cadreAcces"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/lowatt_enedis/wsdl/M023_v1.2.0/xsd/m023/MesuresFinesModel.xsd
+++ b/lowatt_enedis/wsdl/M023_v1.2.0/xsd/m023/MesuresFinesModel.xsd
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:sc="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1"
+            targetNamespace="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+
+    <xs:element name="affaireId" type="sc:affaireId"/>
+    <xs:element name="demandePublicationMesuresFines" type="sc:demandePublicationMesuresFines"/>
+
+    <!-- affaireId Reponse du webservice -->
+    <xs:simpleType name="affaireId">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="8"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- demandePublicationMesuresFines Requete du webservice -->
+    <xs:complexType name="demandePublicationMesuresFines">
+        <xs:sequence>
+            <xs:element name="donneesGenerales" type="sc:donneesGenerales"/>
+            <xs:element name="demande" type="sc:demande"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Données Générales -->
+    <xs:simpleType name="initiateurLogin">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="contratId">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="15"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="referenceDemandeur">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="referenceRegroupement">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="affaireReference">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="8"/>
+            <xs:maxLength value="8"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="donneesGenerales">
+        <xs:sequence>
+            <xs:element name="initiateurLogin" type="sc:initiateurLogin"/>
+            <xs:element name="contratId" type="sc:contratId"/>
+            <xs:element name="referenceDemandeur" type="sc:referenceDemandeur" minOccurs="0"/>
+            <xs:element name="affaireReference" type="sc:affaireReference" minOccurs="0"/>
+            <xs:element name="referenceRegroupement" type="sc:referenceRegroupement" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- demande -->
+    <xs:simpleType name="format">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="JSON"/>
+            <xs:enumeration value="CSV"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="pointId">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{14}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="mesuresTypeCode">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="COURBES"/>
+            <xs:enumeration value="ENERGIE"/>
+            <xs:enumeration value="PMAX"/>
+            <xs:enumeration value="INDEX"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="mesuresCorrigees">
+        <xs:restriction base="xs:boolean"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="dateDebut">
+        <xs:restriction base="xs:date"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="dateFin">
+        <xs:restriction base="xs:date"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="sens">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="SOUTIRAGE"/>
+            <xs:enumeration value="INJECTION"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cadreAcces">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="SERVICE_ACCES"/>
+            <xs:enumeration value="ACCORD_CLIENT"/>
+        </xs:restriction>
+    </xs:simpleType>
+	
+	<xs:complexType name="pointIds">
+        <xs:sequence>
+            <xs:element name="pointId" type="sc:pointId" minOccurs="1" maxOccurs="10000"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="demande">
+        <xs:sequence>
+            <xs:element name="format" type="sc:format" minOccurs="0"/>
+            <xs:element name="pointIds" type="sc:pointIds" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="mesuresTypeCode" type="sc:mesuresTypeCode"/>
+            <xs:element name="mesuresCorrigees" type="sc:mesuresCorrigees" minOccurs="0"/>
+            <xs:element name="dateDebut" type="sc:dateDebut"/>
+            <xs:element name="dateFin" type="sc:dateFin"/>
+            <xs:element name="sens" type="sc:sens"/>
+            <xs:element name="cadreAcces" type="sc:cadreAcces"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/lowatt_enedis/wsdl/M023_v1.2.0/xsd/transverse/ENEDIS.Dictionnaire.Technique.v1.0.xsd
+++ b/lowatt_enedis/wsdl/M023_v1.2.0/xsd/transverse/ENEDIS.Dictionnaire.Technique.v1.0.xsd
@@ -1,0 +1,98 @@
+<xs:schema targetNamespace="http://www.enedis.fr/sge/b2b/technique/v1.0" version="1.0.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0"
+           xmlns:tns="http://schemas.xmlsoap.org/soap/envelope/">
+    <xs:import namespace="http://schemas.xmlsoap.org/soap/envelope/"
+               schemaLocation="./W3C.SoapEnv.xsd"/>
+    <xs:complexType name="AcquittementType">
+        <xs:sequence>
+            <xs:element name="resultat" type="tec:ResultatType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="infoFonctionnelles" type="tec:InfoFonctionnellesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="infoDemandeur" type="tec:InfoDemandeurType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="ResultatType">
+        <xs:simpleContent>
+            <xs:extension base="tec:ResultatLibelleType">
+                <xs:attribute name="code" use="required" type="tec:ResultatCodeType"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="ErreurType">
+        <xs:sequence>
+            <xs:element name="resultat" type="tec:ResultatType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="infoFonctionnelles" type="tec:InfoFonctionnellesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="infoDemandeur" type="tec:InfoDemandeurType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="commentaire" type="tec:ErreurCommentaireType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="erreur" type="tec:ErreurType"/>
+    <xs:element name="acquittement" type="tec:AcquittementType"/>
+    <xs:complexType name="EnteteType">
+        <xs:sequence>
+            <xs:element name="version" type="tec:VersionType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="infoFonctionnelles" type="tec:InfoFonctionnellesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="infoDemandeur" type="tec:InfoDemandeurType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute use="optional" ref="tns:mustUnderstand"/>
+    </xs:complexType>
+    <xs:element name="entete" type="tec:EnteteType"/>
+    <xs:complexType name="InfoDemandeurType">
+        <xs:sequence>
+            <xs:element name="loginDemandeur" type="tec:DemandeurAdresseEmailType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="appelDemandeurId" type="tec:DemandeurAppelIdType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="referenceDemandeur" type="tec:DemandeurRefFrnType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="referenceDemandeurGroupee" type="tec:DemandeurRefFrnType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="ResultatCodeType">
+        <xs:restriction base="xs:string">
+            <xs:length value="6"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ResultatLibelleType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="VersionType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[1-9][0-9]*.[0-9]+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ErreurCommentaireType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="2047"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeurAdresseEmailType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9a-zA-Z][\-._0-9a-zA-Z]{0,255}@[0-9a-zA-Z][\-._0-9a-zA-Z]{1,255}.[a-zA-Z]{2,63}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeurRefFrnType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DemandeurAppelIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="InfoFonctionnellesType">
+        <xs:sequence>
+            <xs:element name="pointId" type="tec:ObjetIdType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="affaireId" type="tec:ObjetIdType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="ObjetIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="20"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/lowatt_enedis/wsdl/M023_v1.2.0/xsd/transverse/W3C.SoapEnv.xsd
+++ b/lowatt_enedis/wsdl/M023_v1.2.0/xsd/transverse/W3C.SoapEnv.xsd
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Schema for the SOAP/1.1 envelope
+
+Portions © 2001 DevelopMentor.
+© 2001 W3C (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved.
+
+This document is governed by the W3C Software License [1] as described in the FAQ [2].
+[1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+[2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+By obtaining, using and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions:
+
+Permission to use, copy, modify, and distribute this software and its documentation, with or without modification,  for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the software and documentation or portions thereof, including modifications, that you make:
+
+1.  The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
+
+2.  Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, a short notice of the following form (hypertext is preferred, text is permitted) should be used within the body of any redistributed or derivative code: "Copyright © 2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/"
+
+3.  Notice of any changes or modifications to the W3C files, including the date changes were made. (We recommend you provide URIs to the location from which the code is derived.)
+
+Original W3C files; http://www.w3.org/2001/06/soap-envelope
+Changes made:
+     - reverted namespace to http://schemas.xmlsoap.org/soap/envelope/
+     - reverted mustUnderstand to only allow 0 and 1 as lexical values
+	 - made encodingStyle a global attribute 20020825
+	 - removed default value from mustUnderstand attribute declaration
+
+THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENTATION.
+
+The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to the software without specific, written prior permission. Title to copyright in this software and any associated documentation will at all times remain with copyright holders.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.xmlsoap.org/soap/envelope/"
+           targetNamespace="http://schemas.xmlsoap.org/soap/envelope/">
+
+
+    <!-- Envelope, header and body -->
+    <xs:element name="Envelope" type="tns:Envelope"/>
+    <xs:complexType name="Envelope">
+        <xs:sequence>
+            <xs:element ref="tns:Header" minOccurs="0"/>
+            <xs:element ref="tns:Body" minOccurs="1"/>
+            <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+
+    <xs:element name="Header" type="tns:Header"/>
+    <xs:complexType name="Header">
+        <xs:sequence>
+            <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+
+    <xs:element name="Body" type="tns:Body"/>
+    <xs:complexType name="Body">
+        <xs:sequence>
+            <xs:any namespace="##any" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>
+                    Prose in the spec does not specify that attributes are allowed on the Body element
+                </xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+
+    <!-- Global Attributes.  The following attributes are intended to be usable via qualified attribute names on any complex type referencing them.  -->
+    <xs:attribute name="mustUnderstand">
+        <xs:simpleType>
+            <xs:restriction base="xs:boolean">
+                <xs:pattern value="0|1"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="actor" type="xs:anyURI"/>
+
+    <xs:simpleType name="encodingStyle">
+        <xs:annotation>
+            <xs:documentation>
+                'encodingStyle' indicates any canonicalization conventions followed in the contents of the containing
+                element. For example, the value 'http://schemas.xmlsoap.org/soap/encoding/' indicates the pattern
+                described in SOAP specification
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:anyURI"/>
+    </xs:simpleType>
+
+    <xs:attribute name="encodingStyle" type="tns:encodingStyle"/>
+    <xs:attributeGroup name="encodingStyle">
+        <xs:attribute ref="tns:encodingStyle"/>
+    </xs:attributeGroup>
+
+    <xs:element name="Fault" type="tns:Fault"/>
+    <xs:complexType name="Fault" final="extension">
+        <xs:annotation>
+            <xs:documentation>
+                Fault reporting structure
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="faultcode" type="xs:QName"/>
+            <xs:element name="faultstring" type="xs:string"/>
+            <xs:element name="faultactor" type="xs:anyURI" minOccurs="0"/>
+            <xs:element name="detail" type="tns:detail" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="detail">
+        <xs:sequence>
+            <xs:any namespace="##any" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/test/data/requests.yaml
+++ b/test/data/requests.yaml
@@ -1862,6 +1862,514 @@ F385B-R1:
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeTransmissionHistoriqueMesures/v1.0
+ITC-GK-R1 (C2-C4) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandeinformationstechniquesetcontractuelles/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationITC>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>98800004935121</pointId>
+              <pointId>98800001544168</pointId>
+              <pointId>98800004938924</pointId>
+              <pointId>98800006694381</pointId>
+              <pointId>98800001220186</pointId>
+            </pointIds>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationITC>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeInformationsTechniquesEtContractuelles/v1.0
+ITC-GK-R1 (C5) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandeinformationstechniquesetcontractuelles/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationITC>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>25150217034354</pointId>
+              <pointId>25825036170379</pointId>
+              <pointId>25999131613803</pointId>
+              <pointId>50086054270348</pointId>
+              <pointId>25262662681289</pointId>
+            </pointIds>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationITC>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeInformationsTechniquesEtContractuelles/v1.0
+MFA-GK-NR1 (C2-C4) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFacturantes>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>98800004935121</pointId>
+              <pointId>98800001544168</pointId>
+              <pointId>98800004938924</pointId>
+              <pointId>98800006694381</pointId>
+              <pointId>98800001220186</pointId>
+            </pointIds>
+            <dateDebut>2023-10-01</dateDebut>
+            <dateFin>2023-08-01</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFacturantes>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFacturantes/v1.0
+MFA-GK-NR1 (C5) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFacturantes>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>25150217034354</pointId>
+              <pointId>25825036170379</pointId>
+              <pointId>25999131613803</pointId>
+              <pointId>50086054270348</pointId>
+              <pointId>25262662681289</pointId>
+            </pointIds>
+            <dateDebut>2023-10-01</dateDebut>
+            <dateFin>2023-08-01</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFacturantes>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFacturantes/v1.0
+MFA-GK-R1 (C2-C4) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFacturantes>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>98800004935121</pointId>
+              <pointId>98800001544168</pointId>
+              <pointId>98800004938924</pointId>
+              <pointId>98800006694381</pointId>
+              <pointId>98800001220186</pointId>
+            </pointIds>
+            <dateDebut>2022-02-21</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFacturantes>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFacturantes/v1.0
+MFA-GK-R1 (C5) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFacturantes>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>25150217034354</pointId>
+              <pointId>25825036170379</pointId>
+              <pointId>25999131613803</pointId>
+              <pointId>50086054270348</pointId>
+              <pointId>25262662681289</pointId>
+            </pointIds>
+            <dateDebut>2022-02-21</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFacturantes>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFacturantes/v1.0
+MFI-GK-NR1 (C2-C4) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFines>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>98800004935121</pointId>
+              <pointId>98800001544168</pointId>
+              <pointId>98800004938924</pointId>
+              <pointId>98800006694381</pointId>
+              <pointId>98800001220186</pointId>
+            </pointIds>
+            <mesuresTypeCode>COURBES</mesuresTypeCode>
+            <mesuresCorrigees>false</mesuresCorrigees>
+            <dateDebut>2022-02-21</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFines>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
+MFI-GK-NR1 (C5) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFines>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>25150217034354</pointId>
+              <pointId>25825036170379</pointId>
+              <pointId>25999131613803</pointId>
+              <pointId>50086054270348</pointId>
+              <pointId>25262662681289</pointId>
+            </pointIds>
+            <mesuresTypeCode>COURBES</mesuresTypeCode>
+            <mesuresCorrigees>false</mesuresCorrigees>
+            <dateDebut>2020-01-01</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFines>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
+MFI-GK-NR2 (C2-C4) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFines>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>98800004935121</pointId>
+              <pointId>98800001544168</pointId>
+              <pointId>98800004938924</pointId>
+              <pointId>98800006694381</pointId>
+              <pointId>98800001220186</pointId>
+            </pointIds>
+            <mesuresTypeCode>INDEX</mesuresTypeCode>
+            <mesuresCorrigees>false</mesuresCorrigees>
+            <dateDebut>2022-02-21</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFines>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
+MFI-GK-NR2 (C5) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFines>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>25150217034354</pointId>
+              <pointId>25825036170379</pointId>
+              <pointId>25999131613803</pointId>
+              <pointId>50086054270348</pointId>
+              <pointId>25262662681289</pointId>
+            </pointIds>
+            <mesuresTypeCode>INDEX</mesuresTypeCode>
+            <mesuresCorrigees>false</mesuresCorrigees>
+            <dateDebut>2020-01-01</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFines>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
+MFI-GK-R1 (C2-C4) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFines>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>98800004935121</pointId>
+              <pointId>98800001544168</pointId>
+              <pointId>98800004938924</pointId>
+              <pointId>98800006694381</pointId>
+              <pointId>98800001220186</pointId>
+            </pointIds>
+            <mesuresTypeCode>ENERGIE</mesuresTypeCode>
+            <mesuresCorrigees>false</mesuresCorrigees>
+            <dateDebut>2022-02-21</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFines>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
+MFI-GK-R1 (C5) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFines>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>25150217034354</pointId>
+              <pointId>25825036170379</pointId>
+              <pointId>25999131613803</pointId>
+              <pointId>50086054270348</pointId>
+              <pointId>25262662681289</pointId>
+            </pointIds>
+            <mesuresTypeCode>ENERGIE</mesuresTypeCode>
+            <mesuresCorrigees>false</mesuresCorrigees>
+            <dateDebut>2022-02-21</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFines>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
+MFI-GK-R2 (C2-C4) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFines>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>98800004935121</pointId>
+            </pointIds>
+            <mesuresTypeCode>COURBES</mesuresTypeCode>
+            <mesuresCorrigees>false</mesuresCorrigees>
+            <dateDebut>2022-02-21</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFines>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
+MFI-GK-R2 (C5) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFines>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>25150217034354</pointId>
+            </pointIds>
+            <mesuresTypeCode>COURBES</mesuresTypeCode>
+            <mesuresCorrigees>false</mesuresCorrigees>
+            <dateDebut>2022-02-21</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFines>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
+MFI-GK-R3 (C2-C4) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFines>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>98800004935121</pointId>
+            </pointIds>
+            <mesuresTypeCode>PMAX</mesuresTypeCode>
+            <mesuresCorrigees>false</mesuresCorrigees>
+            <dateDebut>2022-02-21</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFines>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
+MFI-GK-R3 (C5) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFines>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>25150217034354</pointId>
+            </pointIds>
+            <mesuresTypeCode>PMAX</mesuresTypeCode>
+            <mesuresCorrigees>false</mesuresCorrigees>
+            <dateDebut>2022-02-21</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFines>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
+MFI-GK-R4 (C2-C4) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFines>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>98800004935121</pointId>
+              <pointId>98800001544168</pointId>
+              <pointId>98800004938924</pointId>
+              <pointId>98800006694381</pointId>
+              <pointId>98800001220186</pointId>
+            </pointIds>
+            <mesuresTypeCode>INDEX</mesuresTypeCode>
+            <mesuresCorrigees>false</mesuresCorrigees>
+            <dateDebut>2022-02-21</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFines>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
+MFI-GK-R4 (C5) \*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfines/v1">
+      <SOAP-ENV:Header/>
+      <ns0:Body>
+        <ns1:demandePublicationMesuresFines>
+          <donneesGenerales>
+            <initiateurLogin>test@example.com</initiateurLogin>
+            <contratId>1234</contratId>
+          </donneesGenerales>
+          <demande>
+            <format>JSON</format>
+            <pointIds>
+              <pointId>25150217034354</pointId>
+              <pointId>25825036170379</pointId>
+              <pointId>25999131613803</pointId>
+              <pointId>50086054270348</pointId>
+              <pointId>25262662681289</pointId>
+            </pointIds>
+            <mesuresTypeCode>INDEX</mesuresTypeCode>
+            <mesuresCorrigees>false</mesuresCorrigees>
+            <dateDebut>2022-02-21</dateDebut>
+            <dateFin>2022-02-22</dateFin>
+            <sens>SOUTIRAGE</sens>
+            <cadreAcces>ACCORD_CLIENT</cadreAcces>
+          </demande>
+        </ns1:demandePublicationMesuresFines>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
 RP-NR1:
   data: |
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">

--- a/test/test_lowatt_enedis.py
+++ b/test/test_lowatt_enedis.py
@@ -96,7 +96,13 @@ def test_cli_output(capsys: pytest.CaptureFixture[str]) -> None:
     @le.register(
         "test",
         "RecherchePoint-v2.0",
-        {"--do-raise": {"action": "store_true", "help": "raise a webfault"}},
+        {
+            "--do-raise": {"action": "store_true", "help": "raise a webfault"},
+            "--do-raise-no-value": {
+                "action": "store_true",
+                "help": "raise a webfault with no value",
+            },
+        },
     )
     @le.ws("Test-v1.0")
     def handler(client: Client, args: argparse.Namespace) -> suds.sudsobject.Object:
@@ -108,7 +114,17 @@ def test_cli_output(capsys: pytest.CaptureFixture[str]) -> None:
             fault.detail.erreur.resultat._code = "STG42"
             fault.detail.erreur.resultat.value = "some error"
             obj = suds.sudsobject.Object()
-            obj.error = "foo"
+            raise WebFault(fault=fault, document=obj)
+        if args.do_raise_no_value:
+            # Error as returned by M023 on homologation 23.4
+            fault = suds.sudsobject.Object()
+            fault.faultcode = "soap:Server"
+            fault.faultstring = "Erreur Technique MFI"
+            fault.detail = suds.sudsobject.Object()
+            fault.detail.erreur = suds.sudsobject.Object()
+            fault.detail.erreur.resultat = suds.sudsobject.Object()
+            fault.detail.erreur.resultat._code = ""
+            obj = suds.sudsobject.Object()
             raise WebFault(fault=fault, document=obj)
         obj = suds.sudsobject.Object()
         obj.data = "foo"
@@ -132,6 +148,11 @@ def test_cli_output(capsys: pytest.CaptureFixture[str]) -> None:
                 ["lowatt-enedis", "test", "--do-raise", "--output=json"],
                 1,
                 '{\n  "errcode": "STG42",\n  "errmsg": "some error"\n}',
+            ),
+            (
+                ["lowatt-enedis", "test", "--do-raise-no-value", "--output=json"],
+                1,
+                '{\n  "errcode": "soap:Server",\n  "errmsg": "Erreur Technique MFI"\n}',
             ),
         ):
             with mock.patch.object(sys, "argv", cmd), pytest.raises(SystemExit) as cm:

--- a/test/test_lowatt_enedis.py
+++ b/test/test_lowatt_enedis.py
@@ -238,3 +238,56 @@ def test_measures_resp2py() -> None:
                 "unit": "kWh",
             },
         ]
+
+
+def test_create_from_options_boolean() -> None:
+    """Test that create_from_options() outputs valid boolean values.
+
+    suds does not seem to generate/check those values correctly,
+    the only valid values for xs:boolean are "true" and "false".
+    """
+
+    # From ConsultationMesuresDetaillees-v3.0
+    # <xs:complexType name="Demande">
+    #     <xs:sequence>
+    #         <!-- … -->
+    #         <xs:element name="mesuresCorrigees" type="xs:boolean"/>
+    #         <!-- … -->
+    #     </xs:sequence>
+    # </xs:complexType>
+
+    service, _, _ = le.COMMAND_SERVICE["detailsV3"]
+    client = Client(le.wsdl(service))
+    args = argparse.Namespace()
+
+    for value in [True, False]:
+        args.corrigee = value
+        option_map = {"corrigee": "mesuresCorrigees"}
+        demande = le.create_from_options(client, args, "Demande", option_map)
+        assert demande is not None
+        assert demande.mesuresCorrigees == ("true" if value else "false")
+
+    # From CommanderTransmissionHistoriqueMesures
+    # <xs:simpleType name="BooleenType">
+    #     <xs:restriction base="xs:boolean"/>
+    # </xs:simpleType>
+    # <xs:complexType name="DemandeHistoriqueMesuresType">
+    #     <xs:sequence>
+    #         <!-- … -->
+    #         <xs:element name="mesureCorrigee" type="ds:BooleenType"/>
+    #         <!-- … -->
+    #     </xs:sequence>
+    # </xs:complexType>
+
+    service, _, _ = le.COMMAND_SERVICE["cmdHisto"]
+    client = Client(le.wsdl(service))
+    args = argparse.Namespace()
+
+    for value in [True, False]:
+        args.corrigee = value
+        option_map = {"corrigee": "mesureCorrigee"}
+        demande = le.create_from_options(
+            client, args, "DemandeHistoriqueMesuresType", option_map
+        )
+        assert demande is not None
+        assert demande.mesureCorrigee == ("true" if value else "false")

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -32,7 +32,7 @@ def get_cases(_cache: dict[None, dict[str, str]] = {}) -> dict[str, str]:
                 case = case.strip()
                 assert case not in cases
                 cases[case] = command
-    assert len(cases) == 66
+    assert len(cases) == 84
     _cache[None] = cases
     return cases
 

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -6,7 +6,7 @@ import shlex
 import subprocess
 import sys
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, TypedDict
 from unittest.mock import MagicMock, patch
 
 import freezegun
@@ -16,7 +16,6 @@ import lxml.objectify
 import pkg_resources
 import pytest
 import yaml
-from typing_extensions import TypedDict
 
 import lowatt_enedis.services
 


### PR DESCRIPTION
I am posting the pull request for review, I did not pass the homologation yet.

Commands mix french and english, is there a policy/preference about this ?
For instance:
```
lowatt-enedis cmdHistoFine 25150217034354 ENERGIE --sens INJECTION --from 2023-09-01
```

The `suds` library returns None, while the webservice actually returns a value. I did not manage to find out if the issue is coming from `suds-py3` or the Enedis wsdl files.

For instance:
```
$ lowatt-enedis cmdHistoFine 25150217034354 INDEX
None

$ lowatt-enedis cmdHistoFine  25150217034354 INDEX --output=xml
<?xml version="1.0" encoding="UTF-8"?>
<soap:Envelope>
   <soap:Body>
      <v1:affaireId>M059A9N5</v1:affaireId>
   </soap:Body>
</soap:Envelope>
```
