### PR TITLE
Update for homologation 23.4

### DIFF
--- a/doc/homologation.md
+++ b/doc/homologation.md
@@ -3,13 +3,12 @@ Homologation
 
 This explain how to pass through Enedis homologation process.
 
-This is based on SGE v23.2 (from `Enedis.SGE.REF.0465.Homologation_Catalogue 
-des cas de tests_Tiers_SGE23.2_v1.0.pdf`) cases.
+This is based on SGE v23.4 (from `Enedis.SGE.REF.0465.Homologation_Catalogue
+des cas de tests_Tiers_SGE23.4_v1.0.pdf`) cases.
 
 First setup `lowatt-enedis` and then execute given commands for each services
 you want homologation and report the time the command was run to fill Enedis
 excel file.
-
 
 Setup
 -----
@@ -24,7 +23,6 @@ $ export ENEDIS_CONTRAT=XXX
 $ export ENEDIS_HOMOLOGATION=on
 ```
 
-
 ConsultationDonneesTechniquesContractuelles v1.0
 ------------------------------------------------
 
@@ -36,36 +34,16 @@ ConsultationDonneesTechniquesContractuelles v1.0
 | ADP-R2 (C5)    | `lowatt-enedis technical 25946599093143`                |
 | ADP-NR1        | `lowatt-enedis technical 99999999999999`                |
 
-
 ConsultationMesures v1.1
 ------------------------
 
 | Case              | Command                                                 |
 |-------------------|---------------------------------------------------------|
-| AHC-R1 (C1-C4) \* | `lowatt-enedis measures --autorisation 98800005782026`  |
+| AHC-R1 (C1-C4) \* | `lowatt-enedis measures --autorisation 30001610071843`  |
 | AHC-R1 (C5)       | `lowatt-enedis measures --autorisation 25957452924301`  |
-| AHC-NR1           | `lowatt-enedis measures 98800005782026`                 |
+| AHC-NR1           | `lowatt-enedis measures 30001610071843`                 |
 
 \* Returned "SGT4G3: Aucune mesure trouvée pour ce PRM" on the homologation environment v23.2
-
-
-ConsultationMesuresDetaillees v2.0
-----------------------------------
-
-**The decommissioning of this version is planned for the end of 2023.**
-
-> La version 2 du webservice ConsultationMesureDetaillees sera décomissionné fin 2023.
-
-| Case            | Command                                                                                           |
-|-----------------|---------------------------------------------------------------------------------------------------|
-| CMD2-R1 (C1-C4) | `lowatt-enedis details 30001610071843 COURBE --from 2022-04-01 --to 2022-04-07`                   |
-| CMD2-R1 (C5)    | `lowatt-enedis details 25478147557460 COURBE --from 2022-04-01 --to 2022-04-07`                   |
-| CMD2-R2         | `lowatt-enedis details 30001610071843 COURBE --courbe-type PRI --from 2022-04-01 --to 2022-04-07` |
-| CMD2-R3         | `lowatt-enedis details 25478147557460 ENERGIE --from 2022-04-01 --to 2022-04-07`                  |
-| CMD2-R4         | `lowatt-enedis details 25478147557460 PMAX --from 2022-04-01 --to 2022-04-07`                     |
-| CMD2-NR1        | `lowatt-enedis details 25478147557460 COURBE --from 2022-04-01 --to 2022-04-17`                   |
-| CMD2-NR2        | `lowatt-enedis details 25478147557460 ENERGIE --from 2022-04-01 --to 2022-04-07 --no-autorisation`|
-
 
 ConsultationMesuresDetaillees v3.0
 ----------------------------------
@@ -87,7 +65,6 @@ ConsultationMesuresDetaillees v3.0
 
 \* Returned "SGT4G3: Aucune mesure trouvée pour ce PRM" on the homologation environment v23.2
 
-
 RecherchePoint v2.0
 -------------------
 
@@ -101,57 +78,26 @@ RecherchePoint v2.0
 
 \* Returned "None" on the homologation environment v23.2
 
-
 CommandeAccesDonneesMesures v1.0
 ---------------------------------
 
 | Case                | Command                                                                        |
 |---------------------|--------------------------------------------------------------------------------|
-| ACCES-R1 (C2-C4) \* | `lowatt-enedis cmdAcces 98800002267746 ENERGIE --nom DUPONT`                   |
 | ACCES-R1 (C5) \*\*  | `lowatt-enedis cmdAcces 24380318190106 ENERGIE --nom DUPONT`                   |
-| ACCES-R2 (C2-C4) \* | `lowatt-enedis cmdAcces 98800002267746 COURBE --nom DUPONT`                    |
+| ACCES-R1 (C2-C4) \* | `lowatt-enedis cmdAcces 98800005569823 ENERGIE --nom DUPONT`                   |
 | ACCES-R2 (C5) \*\*  | `lowatt-enedis cmdAcces 24380318190106 COURBE --nom DUPONT`                    |
+| ACCES-R2 (C2-C4) \* | `lowatt-enedis cmdAcces 98800005569823 COURBE --nom DUPONT`                    |
 | ACCES-R3 \*\*       | `lowatt-enedis cmdAcces 24380318190106 PMAX --nom DUPONT`                      |
-| ACCES-R4 (C2-C4) \* | `lowatt-enedis cmdAcces 98800002267746 INDEX --nom DUPONT`                     |
 | ACCES-R4 (C5) \*\*  | `lowatt-enedis cmdAcces 24380318190106 INDEX --nom DUPONT`                     |
-| ACCES-NR1 (C2-C4)   | `lowatt-enedis cmdAcces 98800002267746 ENERGIE --nom DUPONT --no-autorisation` |
+| ACCES-R4 (C2-C4) \* | `lowatt-enedis cmdAcces 98800005569823 INDEX --nom DUPONT`                     |
 | ACCES-NR1 (C5)      | `lowatt-enedis cmdAcces 24380318190106 ENERGIE --nom DUPONT --no-autorisation` |
-| ACCES-NR2 (C2-C4)   | `lowatt-enedis cmdAcces 98800002267746 ENERGIE --nom DUPONT --to 2050-04-21`   |
+| ACCES-NR1 (C2-C4)   | `lowatt-enedis cmdAcces 98800005569823 ENERGIE --nom DUPONT --no-autorisation` |
 | ACCES-NR2 (C5)      | `lowatt-enedis cmdAcces 24380318190106 ENERGIE --nom DUPONT --to 2050-04-21`   |
+| ACCES-NR2 (C2-C4)   | `lowatt-enedis cmdAcces 98800005569823 ENERGIE --nom DUPONT --to 2050-04-21`   |
 
 \* Returned "SGT400: Une erreur fonctionnelle est survenue." on the homologation environment v23.2
 
 \*\* Returned "SGT4B8: Il existe déjà plusieurs demandes en cours sur le point." on the homologation environment v23.2
-
-
-CommandeTransmissionDonneesInfraJ v1.0
---------------------------------------
-
-**This webservice does not work in the Homologation environment.**
-
-> Le webservice CommandeTransmissionDonneesInfraJ ne fonctionne pas dans l’environnement d’Homologation.
-> L’acteur tiers sera donc homologué sur les requêtes.
-> Il ne devra pas prêter attention aux réponses qui lui seront renvoyées via webservice.
-
-| Case         | Command                                                                                                              |
-|--------------|----------------------------------------------------------------------------------------------------------------------|
-| F375A-R1 \*  | `lowatt-enedis cmdInfraJ 98800000000246 --cdc --soutirage --denomination "Raison Sociale"`                           |
-| F375A-NR1 \* | `lowatt-enedis cmdInfraJ 98800000000246 --idx --injection --denomination "Raison Sociale" --no-autorisation`         |
-
-\* Returned "SGT500: Une erreur technique est survenue" on the homologation environment v23.2
-
-
-CommandeTransmissionHistoriqueMesures v1.0
-------------------------------------------
-
-| Case             | Command                                                                                                   |
-|------------------|-----------------------------------------------------------------------------------------------------------|
-| F380-R1 (C1-C4)  | `lowatt-enedis cmdHisto 98800005144497 CDC --pas 10`                                                      |
-| F380-R1 (C5)     | `lowatt-enedis cmdHisto 24551519514005 CDC --pas 30 --nom roro --civilite M`                              |
-| F385B-R1         | `lowatt-enedis cmdHisto 25957452924301 IDX --nom roro --civilite M`                                       |
-| F380-NR1         | `lowatt-enedis cmdHisto 25957452924301 CDC --pas 30 --nom roro --civilite M --from 2010-01-01`            |
-| F385B-NR1        | `lowatt-enedis cmdHisto 25957452924301 IDX --nom roro --civilite M --from 2010-01-01`                     |
-
 
 CommandeCollectePublicationMesures v3.0
 ---------------------------------------
@@ -179,7 +125,6 @@ CommandeCollectePublicationMesures v3.0
 
 \* Returned "SGT400: Une erreur fonctionnelle est survenue." on the homologation environment v23.2
 
-
 RechercherServicesSouscritsMesures v1.0
 ---------------------------------------
 
@@ -189,13 +134,12 @@ RechercherServicesSouscritsMesures v1.0
 > L’acteur tiers sera donc homologué sur la requête pour le segment C2-C4.
 > Il ne devra pas prêter attention à la réponse qui lui sera renvoyée via webservice.
 
-| Case          | Command                                      |
-|---------------|----------------------------------------------|
-| RS-R1 (C5)    | `lowatt-enedis subscriptions 25884515170669` |
+| Case             | Command                                      |
+|------------------|----------------------------------------------|
+| RS-R1 (C5)       | `lowatt-enedis subscriptions 25884515170669` |
 | RS-R1 (C2-C4) \* | `lowatt-enedis subscriptions 98800000000246` |
 
 \* Returned "None" on the homologation environment v23.2
-
 
 CommandeArretServiceSouscritMesures v1.0
 ----------------------------------------
@@ -209,11 +153,27 @@ CommandeArretServiceSouscritMesures v1.0
 | Case                   | Command                                                  |
 |------------------------|----------------------------------------------------------|
 | ASS-R1 (C5) \*\*       | `lowatt-enedis unsubscribe 25884515170669 --id 47761068` |
-| Ass-R1 (C2-C4) \* \*\* | `lowatt-enedis unsubscribe 98800000000246 --id 47761068` |
+| ASS-R1 (C2-C4) \* \*\* | `lowatt-enedis unsubscribe 98800000000246 --id 47761068` |
 
 \* Returned "SGT500: Une erreur technique est survenue" on the homologation environment v23.2
 
 \*\* Use an id returned by RS-R1.
+
+CommandeTransmissionDonneesInfraJ v1.0
+--------------------------------------
+
+**This webservice does not work in the Homologation environment.**
+
+> Le webservice CommandeTransmissionDonneesInfraJ ne fonctionne pas dans l’environnement d’Homologation.
+> L’acteur tiers sera donc homologué sur les requêtes.
+> Il ne devra pas prêter attention aux réponses qui lui seront renvoyées via webservice.
+
+| Case         | Command                                                                                                              |
+|--------------|----------------------------------------------------------------------------------------------------------------------|
+| F375A-R1 \*  | `lowatt-enedis cmdInfraJ 98800000000246 --cdc --soutirage --denomination "Raison Sociale"`                           |
+| F375A-NR1 \* | `lowatt-enedis cmdInfraJ 98800000000246 --idx --injection --denomination "Raison Sociale" --no-autorisation`         |
+
+\* Returned "SGT500: Une erreur technique est survenue" on the homologation environment v23.2
 
 CommandeHistoriqueDonneesMesuresFines v1.0
 ------------------------------------------

--- a/lowatt_enedis/services.py
+++ b/lowatt_enedis/services.py
@@ -22,6 +22,7 @@ SGE web-service mapping to plug them into the CLI.
 """
 
 import argparse
+import warnings
 from datetime import date, datetime, timedelta
 from typing import Any, Iterator, Literal
 
@@ -414,6 +415,11 @@ def measures_resp2py(resp: suds.sudsobject.Object) -> Iterator[dict[str, Any]]:
 def point_detailed_measures(
     client: Client, args: argparse.Namespace
 ) -> suds.sudsobject.Object:
+    warnings.warn(
+        "ConsultationMesuresDetaillees-v2.0 is deprecated and pending for removal",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     demande = create_from_options(
         client,
         args,
@@ -608,6 +614,11 @@ DONNEES_GENERALES_OPTIONS = dict_from_dicts(
 )
 @ws("CommandeTransmissionHistoriqueMesures-v1.0")
 def point_cmd_histo(client: Client, args: argparse.Namespace) -> suds.sudsobject.Object:
+    warnings.warn(
+        "CommandeTransmissionHistoriqueMesures-v1.0 is deprecated and pending for removal",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     _check_mesure_options_consistency(args)
 
     header = client.options.soapheaders

--- a/test/data/requests.yaml
+++ b/test/data/requests.yaml
@@ -14,7 +14,7 @@ ACCES-NR1 (C2-C4):
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
-              <pointId>98800002267746</pointId>
+              <pointId>98800005569823</pointId>
               <initiateurLogin>test@example.com</initiateurLogin>
               <contrat>
                 <contratId>1234</contratId>
@@ -94,7 +94,7 @@ ACCES-NR2 (C2-C4):
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
-              <pointId>98800002267746</pointId>
+              <pointId>98800005569823</pointId>
               <initiateurLogin>test@example.com</initiateurLogin>
               <contrat>
                 <contratId>1234</contratId>
@@ -174,7 +174,7 @@ ACCES-R1 (C2-C4) \*:
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
-              <pointId>98800002267746</pointId>
+              <pointId>98800005569823</pointId>
               <initiateurLogin>test@example.com</initiateurLogin>
               <contrat>
                 <contratId>1234</contratId>
@@ -254,7 +254,7 @@ ACCES-R2 (C2-C4) \*:
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
-              <pointId>98800002267746</pointId>
+              <pointId>98800005569823</pointId>
               <initiateurLogin>test@example.com</initiateurLogin>
               <contrat>
                 <contratId>1234</contratId>
@@ -374,7 +374,7 @@ ACCES-R4 (C2-C4) \*:
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
-              <pointId>98800002267746</pointId>
+              <pointId>98800005569823</pointId>
               <initiateurLogin>test@example.com</initiateurLogin>
               <contrat>
                 <contratId>1234</contratId>
@@ -551,7 +551,7 @@ AHC-NR1:
       </SOAP-ENV:Header>
       <ns0:Body>
         <ns1:consulterMesures>
-          <pointId>98800005782026</pointId>
+          <pointId>30001610071843</pointId>
           <loginDemandeur>test@example.com</loginDemandeur>
           <contratId>1234</contratId>
           <autorisationClient>false</autorisationClient>
@@ -572,7 +572,7 @@ AHC-R1 (C1-C4) \*:
       </SOAP-ENV:Header>
       <ns0:Body>
         <ns1:consulterMesures>
-          <pointId>98800005782026</pointId>
+          <pointId>30001610071843</pointId>
           <loginDemandeur>test@example.com</loginDemandeur>
           <contratId>1234</contratId>
           <autorisationClient>true</autorisationClient>
@@ -601,9 +601,9 @@ AHC-R1 (C5):
       </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/ConsultationMesures/v1.1
-ASS-R1 (C5) \*\*:
+ASS-R1 (C2-C4) \* \*\*:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderarretservicesouscritmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderarretservicesouscritmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -612,36 +612,8 @@ ASS-R1 (C5) \*\*:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderArretServiceSouscritMesures>
-          <demande>
-            <donneesGenerales>
-              <objetCode>ASS</objetCode>
-              <pointId>25884515170669</pointId>
-              <initiateurLogin>test@example.com</initiateurLogin>
-              <contratId>1234</contratId>
-            </donneesGenerales>
-            <arretServiceSouscrit>
-              <serviceSouscritId>47761068</serviceSouscritId>
-            </arretServiceSouscrit>
-          </demande>
-        </ns0:commanderArretServiceSouscritMesures>
-      </ns1:Body>
-    </SOAP-ENV:Envelope>
-  url: https://sge-homologation-b2b.enedis.fr/CommandeArretServiceSouscritMesures/v1.0
-Ass-R1 (C2-C4) \* \*\*:
-  data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderarretservicesouscritmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
-      <SOAP-ENV:Header>
-        <tec:entete>
-          <version>1.0</version>
-          <infoDemandeur>
-            <loginDemandeur>test@example.com</loginDemandeur>
-          </infoDemandeur>
-        </tec:entete>
-      </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderArretServiceSouscritMesures>
+      <ns0:Body>
+        <ns1:commanderArretServiceSouscritMesures>
           <demande>
             <donneesGenerales>
               <objetCode>ASS</objetCode>
@@ -653,8 +625,64 @@ Ass-R1 (C2-C4) \* \*\*:
               <serviceSouscritId>47761068</serviceSouscritId>
             </arretServiceSouscrit>
           </demande>
-        </ns0:commanderArretServiceSouscritMesures>
-      </ns1:Body>
+        </ns1:commanderArretServiceSouscritMesures>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeArretServiceSouscritMesures/v1.0
+ASS-R1 (C5) \*\*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderarretservicesouscritmesures/v1.0">
+      <SOAP-ENV:Header>
+        <tec:entete>
+          <version>1.0</version>
+          <infoDemandeur>
+            <loginDemandeur>test@example.com</loginDemandeur>
+          </infoDemandeur>
+        </tec:entete>
+      </SOAP-ENV:Header>
+      <ns0:Body>
+        <ns1:commanderArretServiceSouscritMesures>
+          <demande>
+            <donneesGenerales>
+              <objetCode>ASS</objetCode>
+              <pointId>25884515170669</pointId>
+              <initiateurLogin>test@example.com</initiateurLogin>
+              <contratId>1234</contratId>
+            </donneesGenerales>
+            <arretServiceSouscrit>
+              <serviceSouscritId>47761068</serviceSouscritId>
+            </arretServiceSouscrit>
+          </demande>
+        </ns1:commanderArretServiceSouscritMesures>
+      </ns0:Body>
+    </SOAP-ENV:Envelope>
+  url: https://sge-homologation-b2b.enedis.fr/CommandeArretServiceSouscritMesures/v1.0
+Ass-R1 (C2-C4) \* \*\*:
+  data: |
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderarretservicesouscritmesures/v1.0">
+      <SOAP-ENV:Header>
+        <tec:entete>
+          <version>1.0</version>
+          <infoDemandeur>
+            <loginDemandeur>test@example.com</loginDemandeur>
+          </infoDemandeur>
+        </tec:entete>
+      </SOAP-ENV:Header>
+      <ns0:Body>
+        <ns1:commanderArretServiceSouscritMesures>
+          <demande>
+            <donneesGenerales>
+              <objetCode>ASS</objetCode>
+              <pointId>98800000000246</pointId>
+              <initiateurLogin>test@example.com</initiateurLogin>
+              <contratId>1234</contratId>
+            </donneesGenerales>
+            <arretServiceSouscrit>
+              <serviceSouscritId>47761068</serviceSouscritId>
+            </arretServiceSouscrit>
+          </demande>
+        </ns1:commanderArretServiceSouscritMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-b2b.enedis.fr/CommandeArretServiceSouscritMesures/v1.0
 CMD2-NR1:

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -32,7 +32,7 @@ def get_cases(_cache: dict[None, dict[str, str]] = {}) -> dict[str, str]:
                 case = case.strip()
                 assert case not in cases
                 cases[case] = command
-    assert len(cases) == 84
+    assert len(cases) == 72
     _cache[None] = cases
     return cases
 


### PR DESCRIPTION
Drop ConsultationMesuresDetaillees-v2.0 and
CommandeTransmissionHistoriqueMesures-v1.0 and issue a deprecation warning when using them.

Update C2C4 test cases and reorder tests as they appear in pdf document.