### PR TITLE
Rework github workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: tox
+
+on:
+  release:
+    types:
+    - published
+
+jobs:
+  publish:
+    name: Publish to PyPI registry
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/lowatt-enedis
+    permissions:
+      id-token: write
+    steps:
+      - name: Switch to using Python 3.11 by default
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+      - name: Install build
+        run: python3 -m pip install --user build
+      - name: Check out src from Git
+        uses: actions/checkout@v2
+      - name: Build dists
+        run: python3 -m build
+      - name: Publish to pypi.org
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,18 +1,12 @@
 name: tox
 
 on:
-  create:
-    tags:
-      - "**"
   push:
     branches:
-      - "main"
+    - "main"
   pull_request:
-  release:
-    types:
-      - published
   schedule:
-    - cron: 0 0 1 * *  # every month
+  - cron: 0 0 1 * *  # every month
 
 jobs:
   build:
@@ -22,106 +16,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - tox_env: check-manifest
-          - tox_env: lint
-          - tox_env: py39
-          - tox_env: py310
-          - tox_env: py311
+        - tox_env: check-manifest
+        - tox_env: lint
+        - tox_env: py39
+        - tox_env: py310
+        - tox_env: py311
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Find python version
-        id: py_ver
-        shell: python
-        if: ${{ contains(matrix.tox_env, 'py') }}
-        run: |
-          v = '${{ matrix.tox_env }}'.split('-')[0].lstrip('py')
-          print('::set-output name=version::{0}.{1}'.format(v[0],v[1:]))
-      - name: Install a default Python
-        uses: actions/setup-python@v2
-        if: ${{ ! contains(matrix.tox_env, 'py') }}
-        with:
-          python-version: 3.11
-      - name: Set up Python version
-        uses: actions/setup-python@v2
-        if: ${{ contains(matrix.tox_env, 'py') }}
-        with:
-          python-version: ${{ steps.py_ver.outputs.version }}
-      - name: Install tox
-        run: |
-          pip install tox
-      - name: Run tox -e ${{ matrix.tox_env }}
-        run: |
-          echo "${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}"
-          ${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}
-
-  publish:
-    name: Publish to PyPI registry
-    needs:
-      - build
-    runs-on: ubuntu-latest
-
-    env:
-      PY_COLORS: 1
-
-    steps:
-      - name: Switch to using Python 3.11 by default
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.11
-      - name: Install build
-        run: python3 -m pip install --user build
-      - name: Check out src from Git
-        uses: actions/checkout@v2
-        with:
-          # Get shallow Git history (default) for release events
-          # but have a complete clone for any other workflows.
-          # Both options fetch tags but since we're going to remove
-          # one from HEAD in non-create-tag workflows, we need full
-          # history for them.
-          fetch-depth: >-
-            ${{
-              (
-                (
-                  github.event_name == 'create' &&
-                  github.event.ref_type == 'tag'
-                ) ||
-                github.event_name == 'release'
-              ) &&
-              1 || 0
-            }}
-      - name: Drop Git tags from HEAD for non-tag-create and non-release events
-        if: >-
-          (
-            github.event_name != 'create' ||
-            github.event.ref_type != 'tag'
-          ) &&
-          github.event_name != 'release'
-        run: >-
-          git tag --points-at HEAD
-          |
-          xargs git tag --delete
-      - name: Build dists
-        run: python3 -m build
-      - name: Publish to test.pypi.org
-        if: >-
-          (
-            github.event_name == 'push' &&
-            github.ref == format(
-              'refs/heads/{0}', github.event.repository.default_branch
-            )
-          ) ||
-          (
-            github.event_name == 'create' &&
-            github.event.ref_type == 'tag'
-          )
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.testpypi_password }}
-          repository_url: https://test.pypi.org/legacy/
-      - name: Publish to pypi.org
-        if: >-  # "create" workflows run separately from "push" & "pull_request"
-          github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.pypi_password }}
+    - uses: actions/checkout@v2
+    - name: Find python version
+      id: py_ver
+      shell: python
+      if: ${{ contains(matrix.tox_env, 'py') }}
+      run: |
+        v = '${{ matrix.tox_env }}'.split('-')[0].lstrip('py')
+        print('::set-output name=version::{0}.{1}'.format(v[0],v[1:]))
+    - name: Install a default Python
+      uses: actions/setup-python@v2
+      if: ${{ ! contains(matrix.tox_env, 'py') }}
+      with:
+        python-version: 3.11
+    - name: Set up Python version
+      uses: actions/setup-python@v2
+      if: ${{ contains(matrix.tox_env, 'py') }}
+      with:
+        python-version: ${{ steps.py_ver.outputs.version }}
+    - name: Install tox
+      run: |
+        pip install tox
+    - name: Run tox -e ${{ matrix.tox_env }}
+      run: |
+        echo "${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}"
+        ${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}


### PR DESCRIPTION
Separate tox and release workflow.
Stop publishing to test.pypi.org since it require a working account with 2FA and so on.
Publish to pypi.org using trusted publishing.