### PR TITLE
Replace pkg_resources with importlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ test = [
     "lxml",
     "freezegun",
     "pyyaml",
+    "importlib_metadata;python_version<'3.10'",
 ]
 typing = [
     "mypy",

--- a/test/test_lowatt_enedis.py
+++ b/test/test_lowatt_enedis.py
@@ -7,7 +7,11 @@ import sys
 from typing import Iterator
 from unittest import mock
 
-import pkg_resources
+if sys.version_info < (3, 10):
+    import importlib_metadata
+else:
+    from importlib import metadata as importlib_metadata
+
 import pytest
 import suds.sudsobject
 from suds import WebFault
@@ -177,12 +181,11 @@ def test_cli_output(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 def test_cli_help() -> None:
-    entrypoint = pkg_resources.get_entry_info(
-        "lowatt_enedis",
-        "console_scripts",
-        "lowatt-enedis",
+    (entrypoint,) = importlib_metadata.entry_points(
+        group="console_scripts",
+        name="lowatt-enedis",
     )
-    assert entrypoint is not None
+    assert entrypoint
     func = entrypoint.load()
     stdout = io.StringIO()
     with (

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -9,11 +9,15 @@ from pathlib import Path
 from typing import Iterator, TypedDict
 from unittest.mock import patch
 
+if sys.version_info < (3, 10):
+    import importlib_metadata
+else:
+    from importlib import metadata as importlib_metadata
+
 import freezegun
 import lxml.doctestcompare
 import lxml.etree
 import lxml.objectify
-import pkg_resources
 import pytest
 import yaml
 
@@ -46,7 +50,7 @@ EXPECTED_FILENAME = Path(__file__).parent / "data" / "requests.yaml"
 
 
 def get_expected(
-    _cache: dict[None, dict[str, ExpectedDict]] = {}
+    _cache: dict[None, dict[str, ExpectedDict]] = {},
 ) -> dict[str, ExpectedDict]:
     with contextlib.suppress(KeyError):
         return _cache[None]
@@ -129,10 +133,9 @@ def test_requests(
         patch.dict("os.environ", {"ENEDIS_CONTRAT": "1234"}),
     ):
         importlib.reload(lowatt_enedis.services)
-    entrypoint = pkg_resources.get_entry_info(
-        "lowatt_enedis",
-        "console_scripts",
-        "lowatt-enedis",
+    (entrypoint,) = importlib_metadata.entry_points(
+        group="console_scripts",
+        name="lowatt-enedis",
     )
     assert entrypoint
     func = entrypoint.load()


### PR DESCRIPTION
Solves `DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html` in tests.

See https://docs.python.org/3.11/library/importlib.metadata.html#entry-points.