### PR TITLE
Remove dateutil dependency

### DIFF
--- a/lowatt_enedis/services.py
+++ b/lowatt_enedis/services.py
@@ -23,11 +23,10 @@ SGE web-service mapping to plug them into the CLI.
 
 import argparse
 import warnings
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Iterator, Literal
 
 import suds.sudsobject
-from dateutil import tz
 from suds.client import Client
 
 from . import (
@@ -39,7 +38,7 @@ from . import (
     ws,
 )
 
-UTC = tz.tzutc()
+UTC = timezone.utc
 ACCORD_CLIENT_OPTIONS = {
     # XXX exclusive option groups
     "--denomination": {

--- a/lowatt_enedis/services.py
+++ b/lowatt_enedis/services.py
@@ -38,7 +38,6 @@ from . import (
     ws,
 )
 
-UTC = timezone.utc
 ACCORD_CLIENT_OPTIONS = {
     # XXX exclusive option groups
     "--denomination": {
@@ -547,7 +546,7 @@ def detailed_measures_resp2py(
     # end = resp.periode.dateFin
     assert len(resp.grandeur) == 1
     for point in resp.grandeur[0].mesure:
-        yield (point.d.astimezone(UTC), point.v)
+        yield (point.d.astimezone(timezone.utc), point.v)
 
 
 def _donnees_generales(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-    "python-dateutil",
     "certifi",
     "suds-py3",
     "rich",
@@ -46,7 +45,6 @@ test = [
 ]
 typing = [
     "mypy",
-    "types-python-dateutil",
     "types-setuptools",
     "types-freezegun",
     "types-PyYAML",

--- a/test/test_lowatt_enedis.py
+++ b/test/test_lowatt_enedis.py
@@ -211,7 +211,7 @@ def test_detailed_measures_resp2py() -> None:
         data = list(le.services.detailed_measures_resp2py(resp))
         assert len(data) == 8
         assert data[0] == (
-            datetime.datetime(2020, 2, 29, 23, tzinfo=le.services.UTC),
+            datetime.datetime(2020, 2, 29, 23, tzinfo=datetime.timezone.utc),
             100,
         )
 


### PR DESCRIPTION
IIUC, we only depend on dateutil to import UTC timezone. It is available in Python core.

(In fact, all timezones are available in `zoneinfo` since Python3.9.)

Also remove `UTC` constant. Could someone be actually relying on this?