### PR TITLE
Update homologation.md 2022->2023

### DIFF
--- a/doc/homologation.md
+++ b/doc/homologation.md
@@ -1,4 +1,4 @@
-Homologation
+<img width="519" alt="image" src="https://github.com/user-attachments/assets/f0f8f2cd-c947-45a3-b314-56d9c2e69d21" />Homologation
 ============
 
 This explain how to pass through Enedis homologation process.
@@ -50,18 +50,18 @@ ConsultationMesuresDetaillees v3.0
 
 | Case               | Command                                                                                                  |
 |--------------------|----------------------------------------------------------------------------------------------------------|
-| CMD3-R1 (C1-C4)    | `lowatt-enedis detailsV3 30001610071843 COURBE --from 2022-04-01 --to 2022-04-07`                        |
-| CMD3-R1 (C5)       | `lowatt-enedis detailsV3 25478147557460 COURBE --from 2022-04-01 --to 2022-04-07`                        |
-| CMD3-R2            | `lowatt-enedis detailsV3 30001610071843 COURBE --courbe-type PRI --from 2022-04-01 --to 2022-04-07`      |
-| CMD3-R3 (C1-C4) \* | `lowatt-enedis detailsV3 30001610071843 ENERGIE --from 2022-04-01 --to 2022-04-07`                       |
-| CMD3-R3 (C5)       | `lowatt-enedis detailsV3 25478147557460 ENERGIE --from 2022-04-01 --to 2022-04-07`                       |
-| CMD3-R4            | `lowatt-enedis detailsV3 25478147557460 PMAX --from 2022-04-01 --to 2022-04-07`                          |
-| CMD3-R5 (C1-C4) \* | `lowatt-enedis detailsV3 30001610071843 INDEX --from 2022-04-01 --to 2022-04-07`                         |
-| CMD3-R5 (C5) \*    | `lowatt-enedis detailsV3 25478147557460 INDEX --from 2022-04-01 --to 2022-04-07`                         |
-| CMD3-R6 (C1-C4) \* | `lowatt-enedis detailsV3 30001610071843 INDEX --from 2022-04-01 --to 2022-04-07 --cadre SERVICE_ACCES`   |
-| CMD3-R6 (C5) \*    | `lowatt-enedis detailsV3 25478147557460 INDEX --from 2022-04-01 --to 2022-04-07 --cadre SERVICE_ACCES`   |
-| CMD3-NR1           | `lowatt-enedis detailsV3 25478147557460 COURBE --from 2022-04-01 --to 2022-04-17`                        |
-| CMD3-NR2 \*        | `lowatt-enedis detailsV3 25478147557460 INDEX --from 2022-04-01 --to 2022-04-17 --cadre SERVICE_ACCES`   |
+| CMD3-R1 (C1-C4)    | `lowatt-enedis detailsV3 30001610071843 COURBE --from 2023-04-01 --to 2023-04-07`                        |
+| CMD3-R1 (C5)       | `lowatt-enedis detailsV3 25478147557460 COURBE --from 2023-04-01 --to 2023-04-07`                        |
+| CMD3-R2            | `lowatt-enedis detailsV3 30001610071843 COURBE --courbe-type PRI --from 2023-04-01 --to 2023-04-07`      |
+| CMD3-R3 (C1-C4) \* | `lowatt-enedis detailsV3 30001610071843 ENERGIE --from 2023-04-01 --to 2023-04-07`                       |
+| CMD3-R3 (C5)       | `lowatt-enedis detailsV3 25478147557460 ENERGIE --from 2023-04-01 --to 2023-04-07`                       |
+| CMD3-R4            | `lowatt-enedis detailsV3 25478147557460 PMAX --from 2023-04-01 --to 2023-04-07`                          |
+| CMD3-R5 (C1-C4) \* | `lowatt-enedis detailsV3 30001610071843 INDEX --from 2023-04-01 --to 2023-04-07`                         |
+| CMD3-R5 (C5) \*    | `lowatt-enedis detailsV3 25478147557460 INDEX --from 2023-04-01 --to 2023-04-07`                         |
+| CMD3-R6 (C1-C4) \* | `lowatt-enedis detailsV3 30001610071843 INDEX --from 2023-04-01 --to 2023-04-07 --cadre SERVICE_ACCES`   |
+| CMD3-R6 (C5) \*    | `lowatt-enedis detailsV3 25478147557460 INDEX --from 2023-04-01 --to 2023-04-07 --cadre SERVICE_ACCES`   |
+| CMD3-NR1           | `lowatt-enedis detailsV3 25478147557460 COURBE --from 2023-04-01 --to 2023-04-17`                        |
+| CMD3-NR2 \*        | `lowatt-enedis detailsV3 25478147557460 INDEX --from 2023-04-01 --to 2023-04-17 --cadre SERVICE_ACCES`   |
 
 \* Returned "SGT4G3: Aucune mesure trouvée pour ce PRM" on the homologation environment v23.2
 


### PR DESCRIPTION
The latest doc specify 2023

<img width="519" alt="image" src="https://github.com/user-attachments/assets/0ab5b7b1-9b66-4f64-841b-623e19648c82" />
