### PR TITLE
Partially revert API change in _HTTPSClientAuthHandler.get_connection…

### DIFF
--- a/lowatt_enedis/certauth.py
+++ b/lowatt_enedis/certauth.py
@@ -45,7 +45,11 @@ class _HTTPSClientAuthHandler(HTTPSHandler):
     def https_open(self, req: Request) -> HTTPResponse:
         return self.do_open(self.get_connection, req)  # type: ignore[arg-type]
 
-    def get_connection(self, host: str, _timeout: int = 300) -> HTTPSConnection:
+    def get_connection(
+        self,
+        host: str,
+        timeout: int = 300,  # noqa: ARG002
+    ) -> HTTPSConnection:
         context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
         context.load_cert_chain(self.cert_file, self.key_file)
         context.load_verify_locations(cafile=certifi.where())


### PR DESCRIPTION
… arguments

Not sure this is the proper fix as the parameter is unused, and get_connection() doesn't seems defined in parent classes.

Will need further investigation but for now just revert change introduced in 877ff73 and use noqa to ignore ruff ARG002 error.

Closes #81