### PR TITLE
Fix AccesDonneesOptionPublication services

### DIFF
--- a/lowatt_enedis/services.py
+++ b/lowatt_enedis/services.py
@@ -1174,7 +1174,7 @@ def point_cmd_acces_donnees(
     if corrigee and not period:
         raise ValueError("'corrigee' option require 'period' to be set")
 
-    demande = client.factory.create("ns1:DemandeType")
+    demande = client.factory.create("DemandeType")
 
     demande.donneesGenerales = create_from_options(
         client,
@@ -1191,12 +1191,12 @@ def point_cmd_acces_donnees(
 
     services = []
     for type_donnees in get_option(args, "type"):
-        service = client.factory.create("ns1:ServiceSouscritType")
+        service = client.factory.create("ServiceSouscritType")
         service.typeDonnees = type_donnees
 
         if period:
-            pub = client.factory.create("ns1:OptionsPublicationType")
-            option = client.factory.create("ns1:OptionPublicationType")
+            pub = client.factory.create("OptionsPublicationType")
+            option = client.factory.create("OptionPublicationType")
             option.periodiciteTransmission = PERIODS[period]
             if corrigee:
                 option.mesuresCorrigees = _boolean(True)
@@ -1208,13 +1208,13 @@ def point_cmd_acces_donnees(
 
         services.append(service)
 
-    demande.servicesSouscrits = client.factory.create("ns1:ServicesSouscritsType")
+    demande.servicesSouscrits = client.factory.create("ServicesSouscritsType")
     demande.servicesSouscrits.serviceSouscrit = services
 
     demande.donneesGenerales.declarationAccordClient = _accord_client(
         client,
         args,
-        xs_accord_type="ns1:DeclarationAccordClientType",
+        xs_accord_type="DeclarationAccordClientType",
         autorisation=not get_option(args, "no_autorisation"),
     )
 
@@ -1242,7 +1242,7 @@ def point_cmd_arret_service_acces_donnees(
     if not service_ids:
         raise ValueError("--service-id est requis (au moins un)")
 
-    demande = client.factory.create("ns1:DemandeType")
+    demande = client.factory.create("DemandeType")
     demande.donneesGenerales = create_from_options(
         client,
         args,
@@ -1254,7 +1254,7 @@ def point_cmd_arret_service_acces_donnees(
     )
     demande.donneesGenerales.contratId = get_option(args, "contrat")
     demande.donneesGenerales.sens = get_option(args, "sens")
-    demande.servicesSouscrits = client.factory.create("ns1:ServicesSouscritsType")
+    demande.servicesSouscrits = client.factory.create("ServicesSouscritsType")
     demande.servicesSouscrits.serviceSouscritId = service_ids
     return client.service.commanderArretServicesAccesDonnees(demande)
 
@@ -1293,7 +1293,7 @@ def point_modify_options_acces_donnees(
 ) -> suds.sudsobject.Object:
     service_id = get_option(args, "service_id")
 
-    demande = client.factory.create("ns1:DemandeType")
+    demande = client.factory.create("DemandeType")
     demande.donneesGenerales = create_from_options(
         client,
         args,
@@ -1305,15 +1305,15 @@ def point_modify_options_acces_donnees(
     )
     demande.donneesGenerales.contratId = get_option(args, "contrat")
     demande.donneesGenerales.sens = get_option(args, "sens")
-    demande.servicesSouscrits = client.factory.create("ns1:ServicesSouscritsType")
-    service = client.factory.create("ns1:ServiceSouscritType")
+    demande.servicesSouscrits = client.factory.create("ServicesSouscritsType")
+    service = client.factory.create("ServiceSouscritType")
     service.serviceSouscritId = service_id
     demande.servicesSouscrits.serviceSouscrit = [service]
 
     for prefix in ("add", "drop"):
-        svc = client.factory.create("ns1:OptionsPublicationType")
+        svc = client.factory.create("OptionsPublicationType")
         if period := get_option(args, f"{prefix}_period"):
-            opt = client.factory.create("ns1:OptionPublicationType")
+            opt = client.factory.create("OptionPublicationType")
             opt.periodiciteTransmission = PERIODS[period]
             if get_option(args, f"{prefix}_corrigee"):
                 opt.mesuresCorrigees = _boolean(True)
@@ -1358,7 +1358,7 @@ def point_cmd_renouvellement_services_acces_donnees(
     if not service_ids:
         raise ValueError("--service-id est requis (au moins un)")
 
-    demande = client.factory.create("ns1:DemandeType")
+    demande = client.factory.create("DemandeType")
 
     demande.donneesGenerales = create_from_options(
         client,
@@ -1375,10 +1375,10 @@ def point_cmd_renouvellement_services_acces_donnees(
     demande.donneesGenerales.declarationAccordClient = _accord_client(
         client,
         args,
-        xs_accord_type="ns1:DeclarationAccordClientType",
+        xs_accord_type="DeclarationAccordClientType",
         autorisation=not get_option(args, "no_autorisation"),
     )
-    demande.servicesSouscrits = client.factory.create("ns1:ServicesSouscritsType")
+    demande.servicesSouscrits = client.factory.create("ServicesSouscritsType")
     demande.servicesSouscrits.serviceSouscritId = service_ids
     return client.service.commanderRenouvellementServicesAccesDonnees(demande)
 

--- a/lowatt_enedis/wsdl/AccesDonneesOptionPublication/Services/CommandeArretServicesAccesDonnees/CommanderArretServicesAccesDonnees-V1.0.wsdl
+++ b/lowatt_enedis/wsdl/AccesDonneesOptionPublication/Services/CommandeArretServicesAccesDonnees/CommanderArretServicesAccesDonnees-V1.0.wsdl
@@ -1,16 +1,16 @@
 <wsdl:definitions name="CommanderArretServicesAccesDonnees-v1.0"
-                  targetNamespace="http://www.enedis.fr/sge/b2b/commanderarretservicesaccesdonnees/v1.0"
+                  targetNamespace="http://www.enedis.fr/sge/ws/commanderarretservicesaccesdonnees/v1.0"
                   xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
                   xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                  xmlns:tns="http://www.enedis.fr/sge/b2b/commanderarretservicesaccesdonnees/v1.0"
-                  xmlns:ope="http://www.enedis.fr/sge/b2b/commanderarretservicesaccesdonnees/v1.0"
+                  xmlns:tns="http://www.enedis.fr/sge/ws/commanderarretservicesaccesdonnees/v1.0"
+                  xmlns:ope="http://www.enedis.fr/sge/ws/commanderarretservicesaccesdonnees/v1.0"
                   xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0">
 
     <wsdl:types>
         <xs:schema>
-            <xs:import schemaLocation="../../xsd/CommanderArretServicesAccesDonnees-V1.0.xsd"
-                       namespace="http://www.enedis.fr/sge/b2b/commanderarretservicesaccesdonnees/v1.0"/>
+            <xs:import schemaLocation="../../xsd/CommanderArretServicesAccesDonnees-v1.0.xsd"
+                       namespace="http://www.enedis.fr/sge/ws/commanderarretservicesaccesdonnees/v1.0"/>
             <xs:import schemaLocation="../../xsd/Dictionnaires/Metier/ENEDIS.Dictionnaire.TypeComplexe.v5.0.xsd"
                        namespace="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc"/>
             <xs:import schemaLocation="../../xsd/Dictionnaires/Technique/ENEDIS.Dictionnaire.Technique.v1.0.xsd"

--- a/lowatt_enedis/wsdl/AccesDonneesOptionPublication/Services/CommandeModificationOptionsServicesAccesDonnees/CommanderModificationOptionsServicesAccesDonnees-V1.0.wsdl
+++ b/lowatt_enedis/wsdl/AccesDonneesOptionPublication/Services/CommandeModificationOptionsServicesAccesDonnees/CommanderModificationOptionsServicesAccesDonnees-V1.0.wsdl
@@ -1,16 +1,16 @@
 <wsdl:definitions name="CommanderModificationOptionsServicesAccesDonnees-V1.0"
-                  targetNamespace="http://www.enedis.fr/sge/b2b/commanderModificationOptionsServicesAccesDonnees/v1.0"
+                  targetNamespace="http://www.enedis.fr/sge/ws/commanderModificationOptionsServicesAccesDonnees/v1.0"
                   xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                  xmlns:tns="http://www.enedis.fr/sge/b2b/commanderModificationOptionsServicesAccesDonnees/v1.0"
-                  xmlns:ope="http://www.enedis.fr/sge/b2b/commanderModificationOptionsServicesAccesDonnees/v1.0"
+                  xmlns:tns="http://www.enedis.fr/sge/ws/commanderModificationOptionsServicesAccesDonnees/v1.0"
+                  xmlns:ope="http://www.enedis.fr/sge/ws/commanderModificationOptionsServicesAccesDonnees/v1.0"
                   xmlns:dic="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc"
                   xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0">
 
     <wsdl:types>
         <xs:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
             <xs:import schemaLocation="../../xsd/CommanderModificationOptionsServicesAccesDonnees-V1.0.xsd"
-                       namespace="http://www.enedis.fr/sge/b2b/commanderModificationOptionsServicesAccesDonnees/v1.0"/>
+                       namespace="http://www.enedis.fr/sge/ws/commanderModificationOptionsServicesAccesDonnees/v1.0"/>
             <xs:import schemaLocation="../../xsd/Dictionnaires/Metier/ENEDIS.Dictionnaire.TypeComplexe.v5.0.xsd"
                        namespace="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc"/>
             <xs:import schemaLocation="../../xsd/Dictionnaires/Technique/ENEDIS.Dictionnaire.Technique.v1.0.xsd"

--- a/lowatt_enedis/wsdl/AccesDonneesOptionPublication/Services/CommandeRenouvellementServicesAccesDonnees/CommanderRenouvellementServicesAccesDonnees-V1.0.wsdl
+++ b/lowatt_enedis/wsdl/AccesDonneesOptionPublication/Services/CommandeRenouvellementServicesAccesDonnees/CommanderRenouvellementServicesAccesDonnees-V1.0.wsdl
@@ -1,16 +1,16 @@
 <wsdl:definitions name="CommanderRenouvellementServicesAccesDonnees-V1.0"
-                  targetNamespace="http://www.enedis.fr/sge/b2b/commanderRenouvellementServicesAccesDonnees/v1.0"
+                  targetNamespace="http://www.enedis.fr/sge/ws/commanderRenouvellementServicesAccesDonnees/v1.0"
                   xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                  xmlns:tns="http://www.enedis.fr/sge/b2b/commanderRenouvellementServicesAccesDonnees/v1.0"
-                  xmlns:ope="http://www.enedis.fr/sge/b2b/commanderRenouvellementServicesAccesDonnees/v1.0"
+                  xmlns:tns="http://www.enedis.fr/sge/ws/commanderRenouvellementServicesAccesDonnees/v1.0"
+                  xmlns:ope="http://www.enedis.fr/sge/ws/commanderRenouvellementServicesAccesDonnees/v1.0"
                   xmlns:dic="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc"
                   xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0">
 
     <wsdl:types>
         <xs:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
             <xs:import schemaLocation="../../xsd/CommanderRenouvellementServicesAccesDonnees-V1.0.xsd"
-                       namespace="http://www.enedis.fr/sge/b2b/commanderRenouvellementServicesAccesDonnees/v1.0"/>
+                       namespace="http://www.enedis.fr/sge/ws/commanderRenouvellementServicesAccesDonnees/v1.0"/>
             <xs:import schemaLocation="../../xsd/Dictionnaires/Metier/ENEDIS.Dictionnaire.TypeComplexe.v5.0.xsd"
                        namespace="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc"/>
             <xs:import schemaLocation="../../xsd/Dictionnaires/Technique/ENEDIS.Dictionnaire.Technique.v1.0.xsd"

--- a/lowatt_enedis/wsdl/AccesDonneesOptionPublication/Services/CommandeServicesAccesDonnees/CommanderServicesAccesDonnees-V1.0.wsdl
+++ b/lowatt_enedis/wsdl/AccesDonneesOptionPublication/Services/CommandeServicesAccesDonnees/CommanderServicesAccesDonnees-V1.0.wsdl
@@ -1,16 +1,16 @@
 <wsdl:definitions name="CommanderServicesAccesDonnees-V1.0"
-                  targetNamespace="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0"
+                  targetNamespace="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0"
                   xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                  xmlns:tns="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0"
-                  xmlns:ope="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0"
+                  xmlns:tns="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0"
+                  xmlns:ope="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0"
                   xmlns:dic="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc"
                   xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0">
 
     <wsdl:types>
         <xs:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
             <xs:import schemaLocation="../../xsd/CommanderServicesAccesDonnees-V1.0.xsd"
-                       namespace="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0"/>
+                       namespace="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0"/>
             <xs:import schemaLocation="../../xsd/Dictionnaires/Metier/ENEDIS.Dictionnaire.TypeComplexe.v5.0.xsd"
                        namespace="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc"/>
             <xs:import schemaLocation="../../xsd/Dictionnaires/Technique/ENEDIS.Dictionnaire.Technique.v1.0.xsd"

--- a/lowatt_enedis/wsdl/AccesDonneesOptionPublication/xsd/CommanderArretServicesAccesDonnees-v1.0.xsd
+++ b/lowatt_enedis/wsdl/AccesDonneesOptionPublication/xsd/CommanderArretServicesAccesDonnees-v1.0.xsd
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:sc="http://www.enedis.fr/sge/b2b/commanderarretservicesaccesdonnees/v1.0"
+           xmlns:sc="http://www.enedis.fr/sge/ws/commanderarretservicesaccesdonnees/v1.0"
            xmlns:ds="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/ds"
-           targetNamespace="http://www.enedis.fr/sge/b2b/commanderarretservicesaccesdonnees/v1.0" version="1.0.0">
-   <xs:import namespace="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc" schemaLocation="./Dictionnaires/Metier/ENEDIS.Dictionnaire.TypeComplexe.v5.0.xsd"/>
-   <xs:import namespace="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/ds" schemaLocation="./Dictionnaires/Metier/ENEDIS.Dictionnaire.TypeSimple.v5.0.xsd"/>
+           targetNamespace="http://www.enedis.fr/sge/ws/commanderarretservicesaccesdonnees/v1.0" version="1.0.0">
+
+    <xs:import namespace="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/dc"
+               schemaLocation="../xsd/ENEDIS.Dictionnaire.TypeComplexe.v5.0.xsd"/>
+    <xs:import namespace="http://www.enedis.fr/sge/b2b/dictionnaire/v5.0/ds"
+               schemaLocation="../xsd/ENEDIS.Dictionnaire.TypeSimple.v5.0.xsd"/>
+
     <xs:element name="commanderArretServicesAccesDonnees" type="sc:CommanderArretServicesAccesDonneesType"/>
     <xs:element name="commanderArretServicesAccesDonneesResponse"
                 type="sc:CommanderArretServicesAccesDonneesResponseType"/>

--- a/lowatt_enedis/wsdl/AccesDonneesOptionPublication/xsd/CommanderModificationOptionsServicesAccesDonnees-V1.0.xsd
+++ b/lowatt_enedis/wsdl/AccesDonneesOptionPublication/xsd/CommanderModificationOptionsServicesAccesDonnees-V1.0.xsd
@@ -1,6 +1,6 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:sc="http://www.enedis.fr/sge/b2b/commanderModificationOptionsServicesAccesDonnees/v1.0"
-           targetNamespace="http://www.enedis.fr/sge/b2b/commanderModificationOptionsServicesAccesDonnees/v1.0" version="1.0.0">
+           xmlns:sc="http://www.enedis.fr/sge/ws/commanderModificationOptionsServicesAccesDonnees/v1.0"
+           targetNamespace="http://www.enedis.fr/sge/ws/commanderModificationOptionsServicesAccesDonnees/v1.0" version="1.0.0">
     <xs:element name="commanderModificationOptionsServicesAccesDonnees" type="sc:CommanderModificationOptionsServicesAccesDonneesType"/>
     <xs:element name="commanderModificationOptionsServicesAccesDonneesResponse" type="sc:CommanderModificationOptionsServicesAccesDonneesResponseType"/>
     <xs:complexType name="CommanderModificationOptionsServicesAccesDonneesType">

--- a/lowatt_enedis/wsdl/AccesDonneesOptionPublication/xsd/CommanderRenouvellementServicesAccesDonnees-V1.0.xsd
+++ b/lowatt_enedis/wsdl/AccesDonneesOptionPublication/xsd/CommanderRenouvellementServicesAccesDonnees-V1.0.xsd
@@ -1,6 +1,6 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:sc="http://www.enedis.fr/sge/b2b/commanderRenouvellementServicesAccesDonnees/v1.0"
-           targetNamespace="http://www.enedis.fr/sge/b2b/commanderRenouvellementServicesAccesDonnees/v1.0" version="1.0.0">
+           xmlns:sc="http://www.enedis.fr/sge/ws/commanderRenouvellementServicesAccesDonnees/v1.0"
+           targetNamespace="http://www.enedis.fr/sge/ws/commanderRenouvellementServicesAccesDonnees/v1.0" version="1.0.0">
     <xs:element name="commanderRenouvellementServicesAccesDonnees" type="sc:RenouvelerServicesAccesType"/>
     <xs:element name="commanderRenouvellementServicesAccesDonneesResponse" type="sc:RenouvelerServicesAccesResponseType"/>
     <xs:complexType name="RenouvelerServicesAccesType">

--- a/lowatt_enedis/wsdl/AccesDonneesOptionPublication/xsd/CommanderServicesAccesDonnees-V1.0.xsd
+++ b/lowatt_enedis/wsdl/AccesDonneesOptionPublication/xsd/CommanderServicesAccesDonnees-V1.0.xsd
@@ -1,6 +1,6 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:sc="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0"
-           targetNamespace="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" version="1.0.0">
+           xmlns:sc="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0"
+           targetNamespace="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0" version="1.0.0">
     <xs:element name="commanderServicesAccesDonnees" type="sc:CommanderServicesAccesDonneesType"/>
     <xs:element name="commanderServicesAccesDonneesResponse" type="sc:CommanderServicesAccesDonneesResponseType"/>
     <xs:complexType name="CommanderServicesAccesDonneesType">

--- a/lowatt_enedis/wsdl/AccesDonneesOptionPublication/xsd/ENEDIS.Dictionnaire.TypeComplexe.v5.0.xsd
+++ b/lowatt_enedis/wsdl/AccesDonneesOptionPublication/xsd/ENEDIS.Dictionnaire.TypeComplexe.v5.0.xsd
@@ -1,0 +1,1 @@
+Dictionnaires/Metier/ENEDIS.Dictionnaire.TypeComplexe.v5.0.xsd

--- a/lowatt_enedis/wsdl/AccesDonneesOptionPublication/xsd/ENEDIS.Dictionnaire.TypeSimple.v5.0.xsd
+++ b/lowatt_enedis/wsdl/AccesDonneesOptionPublication/xsd/ENEDIS.Dictionnaire.TypeSimple.v5.0.xsd
@@ -1,0 +1,1 @@
+Dictionnaires/Metier/ENEDIS.Dictionnaire.TypeSimple.v5.0.xsd

--- a/test/data/requests.yaml
+++ b/test/data/requests.yaml
@@ -1,6 +1,6 @@
 ACCES-NR1 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -9,8 +9,8 @@ ACCES-NR1 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderAccesDonneesMesures>
+      <ns0:Body>
+        <ns1:commanderAccesDonneesMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -34,13 +34,13 @@ ACCES-NR1 (C2-C4):
               <injection>false</injection>
             </accesDonnees>
           </demande>
-        </ns0:commanderAccesDonneesMesures>
-      </ns1:Body>
+        </ns1:commanderAccesDonneesMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-NR1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -49,8 +49,8 @@ ACCES-NR1 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderAccesDonneesMesures>
+      <ns0:Body>
+        <ns1:commanderAccesDonneesMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -74,13 +74,13 @@ ACCES-NR1 (C5):
               <injection>false</injection>
             </accesDonnees>
           </demande>
-        </ns0:commanderAccesDonneesMesures>
-      </ns1:Body>
+        </ns1:commanderAccesDonneesMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-NR2 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -89,8 +89,8 @@ ACCES-NR2 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderAccesDonneesMesures>
+      <ns0:Body>
+        <ns1:commanderAccesDonneesMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -114,13 +114,13 @@ ACCES-NR2 (C2-C4):
               <injection>false</injection>
             </accesDonnees>
           </demande>
-        </ns0:commanderAccesDonneesMesures>
-      </ns1:Body>
+        </ns1:commanderAccesDonneesMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-NR2 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -129,8 +129,8 @@ ACCES-NR2 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderAccesDonneesMesures>
+      <ns0:Body>
+        <ns1:commanderAccesDonneesMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -154,13 +154,13 @@ ACCES-NR2 (C5):
               <injection>false</injection>
             </accesDonnees>
           </demande>
-        </ns0:commanderAccesDonneesMesures>
-      </ns1:Body>
+        </ns1:commanderAccesDonneesMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R1 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -169,8 +169,8 @@ ACCES-R1 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderAccesDonneesMesures>
+      <ns0:Body>
+        <ns1:commanderAccesDonneesMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -194,8 +194,8 @@ ACCES-R1 (C2-C4):
               <injection>false</injection>
             </accesDonnees>
           </demande>
-        </ns0:commanderAccesDonneesMesures>
-      </ns1:Body>
+        </ns1:commanderAccesDonneesMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R1 (C2-C4) \*:
@@ -240,7 +240,7 @@ ACCES-R1 (C2-C4) \*:
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -249,8 +249,8 @@ ACCES-R1 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderAccesDonneesMesures>
+      <ns0:Body>
+        <ns1:commanderAccesDonneesMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -274,8 +274,8 @@ ACCES-R1 (C5):
               <injection>false</injection>
             </accesDonnees>
           </demande>
-        </ns0:commanderAccesDonneesMesures>
-      </ns1:Body>
+        </ns1:commanderAccesDonneesMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R1 (C5) \*\*:
@@ -320,7 +320,7 @@ ACCES-R1 (C5) \*\*:
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R2 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -329,8 +329,8 @@ ACCES-R2 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderAccesDonneesMesures>
+      <ns0:Body>
+        <ns1:commanderAccesDonneesMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -354,8 +354,8 @@ ACCES-R2 (C2-C4):
               <injection>false</injection>
             </accesDonnees>
           </demande>
-        </ns0:commanderAccesDonneesMesures>
-      </ns1:Body>
+        </ns1:commanderAccesDonneesMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R2 (C2-C4) \*:
@@ -400,7 +400,7 @@ ACCES-R2 (C2-C4) \*:
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R2 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -409,8 +409,8 @@ ACCES-R2 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderAccesDonneesMesures>
+      <ns0:Body>
+        <ns1:commanderAccesDonneesMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -434,8 +434,8 @@ ACCES-R2 (C5):
               <injection>false</injection>
             </accesDonnees>
           </demande>
-        </ns0:commanderAccesDonneesMesures>
-      </ns1:Body>
+        </ns1:commanderAccesDonneesMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R2 (C5) \*\*:
@@ -480,7 +480,7 @@ ACCES-R2 (C5) \*\*:
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R3:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -489,8 +489,8 @@ ACCES-R3:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderAccesDonneesMesures>
+      <ns0:Body>
+        <ns1:commanderAccesDonneesMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -514,8 +514,8 @@ ACCES-R3:
               <injection>false</injection>
             </accesDonnees>
           </demande>
-        </ns0:commanderAccesDonneesMesures>
-      </ns1:Body>
+        </ns1:commanderAccesDonneesMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R3 \*\*:
@@ -560,7 +560,7 @@ ACCES-R3 \*\*:
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R4 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -569,8 +569,8 @@ ACCES-R4 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderAccesDonneesMesures>
+      <ns0:Body>
+        <ns1:commanderAccesDonneesMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -594,8 +594,8 @@ ACCES-R4 (C2-C4):
               <injection>false</injection>
             </accesDonnees>
           </demande>
-        </ns0:commanderAccesDonneesMesures>
-      </ns1:Body>
+        </ns1:commanderAccesDonneesMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R4 (C2-C4) \*:
@@ -640,7 +640,7 @@ ACCES-R4 (C2-C4) \*:
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R4 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderaccesdonneesmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -649,8 +649,8 @@ ACCES-R4 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderAccesDonneesMesures>
+      <ns0:Body>
+        <ns1:commanderAccesDonneesMesures>
           <demande>
             <donneesGenerales>
               <objetCode>AME</objetCode>
@@ -674,8 +674,8 @@ ACCES-R4 (C5):
               <injection>false</injection>
             </accesDonnees>
           </demande>
-        </ns0:commanderAccesDonneesMesures>
-      </ns1:Body>
+        </ns1:commanderAccesDonneesMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ACCES-R4 (C5) \*\*:
@@ -720,7 +720,7 @@ ACCES-R4 (C5) \*\*:
   url: https://sge-homologation-ws.enedis.fr/CommanderAccesDonneesMesures/v1.0
 ADP-NR1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consulterdonneestechniquescontractuelles/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consulterdonneestechniquescontractuelles/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -729,18 +729,18 @@ ADP-NR1:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:consulterDonneesTechniquesContractuelles>
+      <ns0:Body>
+        <ns1:consulterDonneesTechniquesContractuelles>
           <pointId>99999999999999</pointId>
           <loginUtilisateur>test@example.com</loginUtilisateur>
           <autorisationClient>false</autorisationClient>
-        </ns0:consulterDonneesTechniquesContractuelles>
-      </ns1:Body>
+        </ns1:consulterDonneesTechniquesContractuelles>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationDonneesTechniquesContractuelles/v1.0
 ADP-R1 (C1-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consulterdonneestechniquescontractuelles/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consulterdonneestechniquescontractuelles/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -749,18 +749,18 @@ ADP-R1 (C1-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:consulterDonneesTechniquesContractuelles>
+      <ns0:Body>
+        <ns1:consulterDonneesTechniquesContractuelles>
           <pointId>98800004847471</pointId>
           <loginUtilisateur>test@example.com</loginUtilisateur>
           <autorisationClient>true</autorisationClient>
-        </ns0:consulterDonneesTechniquesContractuelles>
-      </ns1:Body>
+        </ns1:consulterDonneesTechniquesContractuelles>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationDonneesTechniquesContractuelles/v1.0
 ADP-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consulterdonneestechniquescontractuelles/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consulterdonneestechniquescontractuelles/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -769,18 +769,18 @@ ADP-R1 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:consulterDonneesTechniquesContractuelles>
+      <ns0:Body>
+        <ns1:consulterDonneesTechniquesContractuelles>
           <pointId>25946599093143</pointId>
           <loginUtilisateur>test@example.com</loginUtilisateur>
           <autorisationClient>true</autorisationClient>
-        </ns0:consulterDonneesTechniquesContractuelles>
-      </ns1:Body>
+        </ns1:consulterDonneesTechniquesContractuelles>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationDonneesTechniquesContractuelles/v1.0
 ADP-R2 (C1-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consulterdonneestechniquescontractuelles/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consulterdonneestechniquescontractuelles/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -789,18 +789,18 @@ ADP-R2 (C1-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:consulterDonneesTechniquesContractuelles>
+      <ns0:Body>
+        <ns1:consulterDonneesTechniquesContractuelles>
           <pointId>98800004847471</pointId>
           <loginUtilisateur>test@example.com</loginUtilisateur>
           <autorisationClient>false</autorisationClient>
-        </ns0:consulterDonneesTechniquesContractuelles>
-      </ns1:Body>
+        </ns1:consulterDonneesTechniquesContractuelles>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationDonneesTechniquesContractuelles/v1.0
 ADP-R2 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consulterdonneestechniquescontractuelles/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consulterdonneestechniquescontractuelles/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -809,18 +809,18 @@ ADP-R2 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:consulterDonneesTechniquesContractuelles>
+      <ns0:Body>
+        <ns1:consulterDonneesTechniquesContractuelles>
           <pointId>25946599093143</pointId>
           <loginUtilisateur>test@example.com</loginUtilisateur>
           <autorisationClient>false</autorisationClient>
-        </ns0:consulterDonneesTechniquesContractuelles>
-      </ns1:Body>
+        </ns1:consulterDonneesTechniquesContractuelles>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationDonneesTechniquesContractuelles/v1.0
 AHC-NR1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.1</version>
@@ -829,19 +829,19 @@ AHC-NR1:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:consulterMesures>
+      <ns0:Body>
+        <ns1:consulterMesures>
           <pointId>25162373298976</pointId>
           <loginDemandeur>test@example.com</loginDemandeur>
           <contratId>1234</contratId>
           <autorisationClient>false</autorisationClient>
-        </ns0:consulterMesures>
-      </ns1:Body>
+        </ns1:consulterMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesures/v1.1
 AHC-R1 (C1-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.1</version>
@@ -850,14 +850,14 @@ AHC-R1 (C1-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:consulterMesures>
+      <ns0:Body>
+        <ns1:consulterMesures>
           <pointId>98800000396971</pointId>
           <loginDemandeur>test@example.com</loginDemandeur>
           <contratId>1234</contratId>
           <autorisationClient>true</autorisationClient>
-        </ns0:consulterMesures>
-      </ns1:Body>
+        </ns1:consulterMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesures/v1.1
 AHC-R1 (C1-C4) \*:
@@ -883,7 +883,7 @@ AHC-R1 (C1-C4) \*:
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesures/v1.1
 AHC-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultermesures/v1.1">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.1</version>
@@ -892,19 +892,19 @@ AHC-R1 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:consulterMesures>
+      <ns0:Body>
+        <ns1:consulterMesures>
           <pointId>25162373298976</pointId>
           <loginDemandeur>test@example.com</loginDemandeur>
           <contratId>1234</contratId>
           <autorisationClient>true</autorisationClient>
-        </ns0:consulterMesures>
-      </ns1:Body>
+        </ns1:consulterMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesures/v1.1
 ASAD-R1 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderarretservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderarretservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -913,8 +913,8 @@ ASAD-R1 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderArretServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderArretServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>98800003605600</pointId>
@@ -926,13 +926,13 @@ ASAD-R1 (C2-C4):
               <serviceSouscritId>666</serviceSouscritId>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderArretServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderArretServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeArretServicesAccesDonnees/v1.0
 ASAD-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderarretservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderarretservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -941,8 +941,8 @@ ASAD-R1 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderArretServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderArretServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>24380318190106</pointId>
@@ -954,13 +954,13 @@ ASAD-R1 (C5):
               <serviceSouscritId>666</serviceSouscritId>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderArretServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderArretServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeArretServicesAccesDonnees/v1.0
 ASS-R1 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderarretservicesouscritmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderarretservicesouscritmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -969,8 +969,8 @@ ASS-R1 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderArretServiceSouscritMesures>
+      <ns0:Body>
+        <ns1:commanderArretServiceSouscritMesures>
           <demande>
             <donneesGenerales>
               <objetCode>ASS</objetCode>
@@ -982,8 +982,8 @@ ASS-R1 (C2-C4):
               <serviceSouscritId>47761068</serviceSouscritId>
             </arretServiceSouscrit>
           </demande>
-        </ns0:commanderArretServiceSouscritMesures>
-      </ns1:Body>
+        </ns1:commanderArretServiceSouscritMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeArretServiceSouscritMesures/v1.0
 ASS-R1 (C2-C4) \* \*\*:
@@ -1016,7 +1016,7 @@ ASS-R1 (C2-C4) \* \*\*:
   url: https://sge-homologation-ws.enedis.fr/CommandeArretServiceSouscritMesures/v1.0
 ASS-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderarretservicesouscritmesures/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderarretservicesouscritmesures/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -1025,8 +1025,8 @@ ASS-R1 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderArretServiceSouscritMesures>
+      <ns0:Body>
+        <ns1:commanderArretServiceSouscritMesures>
           <demande>
             <donneesGenerales>
               <objetCode>ASS</objetCode>
@@ -1038,8 +1038,8 @@ ASS-R1 (C5):
               <serviceSouscritId>47761068</serviceSouscritId>
             </arretServiceSouscrit>
           </demande>
-        </ns0:commanderArretServiceSouscritMesures>
-      </ns1:Body>
+        </ns1:commanderArretServiceSouscritMesures>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeArretServiceSouscritMesures/v1.0
 ASS-R1 (C5) \*\*:
@@ -1255,10 +1255,10 @@ CMD2-R4:
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v2.0
 CMD3-NR1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetailleesV3>
+      <ns0:Body>
+        <ns1:consulterMesuresDetailleesV3>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>25162373298976</pointId>
@@ -1270,16 +1270,16 @@ CMD3-NR1:
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns0:consulterMesuresDetailleesV3>
-      </ns1:Body>
+        </ns1:consulterMesuresDetailleesV3>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-NR2:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetailleesV3>
+      <ns0:Body>
+        <ns1:consulterMesuresDetailleesV3>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>25162373298976</pointId>
@@ -1291,8 +1291,8 @@ CMD3-NR2:
             <sens>SOUTIRAGE</sens>
             <cadreAcces>SERVICE_ACCES</cadreAcces>
           </demande>
-        </ns0:consulterMesuresDetailleesV3>
-      </ns1:Body>
+        </ns1:consulterMesuresDetailleesV3>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-NR2 \*:
@@ -1318,10 +1318,10 @@ CMD3-NR2 \*:
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R1 (C1-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetailleesV3>
+      <ns0:Body>
+        <ns1:consulterMesuresDetailleesV3>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>98800001144455</pointId>
@@ -1333,16 +1333,16 @@ CMD3-R1 (C1-C4):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns0:consulterMesuresDetailleesV3>
-      </ns1:Body>
+        </ns1:consulterMesuresDetailleesV3>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetailleesV3>
+      <ns0:Body>
+        <ns1:consulterMesuresDetailleesV3>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>25162373298976</pointId>
@@ -1354,16 +1354,16 @@ CMD3-R1 (C5):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns0:consulterMesuresDetailleesV3>
-      </ns1:Body>
+        </ns1:consulterMesuresDetailleesV3>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R2:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetailleesV3>
+      <ns0:Body>
+        <ns1:consulterMesuresDetailleesV3>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>98800001144455</pointId>
@@ -1375,16 +1375,16 @@ CMD3-R2:
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns0:consulterMesuresDetailleesV3>
-      </ns1:Body>
+        </ns1:consulterMesuresDetailleesV3>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R3 (C1-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetailleesV3>
+      <ns0:Body>
+        <ns1:consulterMesuresDetailleesV3>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>98800001144455</pointId>
@@ -1396,8 +1396,8 @@ CMD3-R3 (C1-C4):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns0:consulterMesuresDetailleesV3>
-      </ns1:Body>
+        </ns1:consulterMesuresDetailleesV3>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R3 (C1-C4) \*:
@@ -1423,10 +1423,10 @@ CMD3-R3 (C1-C4) \*:
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R3 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetailleesV3>
+      <ns0:Body>
+        <ns1:consulterMesuresDetailleesV3>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>25162373298976</pointId>
@@ -1438,16 +1438,16 @@ CMD3-R3 (C5):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns0:consulterMesuresDetailleesV3>
-      </ns1:Body>
+        </ns1:consulterMesuresDetailleesV3>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R4:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetailleesV3>
+      <ns0:Body>
+        <ns1:consulterMesuresDetailleesV3>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>25162373298976</pointId>
@@ -1460,16 +1460,16 @@ CMD3-R4:
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns0:consulterMesuresDetailleesV3>
-      </ns1:Body>
+        </ns1:consulterMesuresDetailleesV3>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R5 (C1-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetailleesV3>
+      <ns0:Body>
+        <ns1:consulterMesuresDetailleesV3>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>98800001144455</pointId>
@@ -1481,8 +1481,8 @@ CMD3-R5 (C1-C4):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns0:consulterMesuresDetailleesV3>
-      </ns1:Body>
+        </ns1:consulterMesuresDetailleesV3>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R5 (C1-C4) \*:
@@ -1508,10 +1508,10 @@ CMD3-R5 (C1-C4) \*:
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R5 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetailleesV3>
+      <ns0:Body>
+        <ns1:consulterMesuresDetailleesV3>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>25162373298976</pointId>
@@ -1523,8 +1523,8 @@ CMD3-R5 (C5):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns0:consulterMesuresDetailleesV3>
-      </ns1:Body>
+        </ns1:consulterMesuresDetailleesV3>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R5 (C5) \*:
@@ -1550,10 +1550,10 @@ CMD3-R5 (C5) \*:
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R6 (C1-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetailleesV3>
+      <ns0:Body>
+        <ns1:consulterMesuresDetailleesV3>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>98800001144455</pointId>
@@ -1565,8 +1565,8 @@ CMD3-R6 (C1-C4):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>SERVICE_ACCES</cadreAcces>
           </demande>
-        </ns0:consulterMesuresDetailleesV3>
-      </ns1:Body>
+        </ns1:consulterMesuresDetailleesV3>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R6 (C1-C4) \*:
@@ -1592,10 +1592,10 @@ CMD3-R6 (C1-C4) \*:
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R6 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/consultationmesuresdetaillees/common">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:consulterMesuresDetailleesV3>
+      <ns0:Body>
+        <ns1:consulterMesuresDetailleesV3>
           <demande>
             <initiateurLogin>test@example.com</initiateurLogin>
             <pointId>25162373298976</pointId>
@@ -1607,8 +1607,8 @@ CMD3-R6 (C5):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>SERVICE_ACCES</cadreAcces>
           </demande>
-        </ns0:consulterMesuresDetailleesV3>
-      </ns1:Body>
+        </ns1:consulterMesuresDetailleesV3>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/ConsultationMesuresDetaillees/v3.0
 CMD3-R6 (C5) \*:
@@ -2511,10 +2511,10 @@ F385B-R1:
   url: https://sge-homologation-ws.enedis.fr/CommandeTransmissionHistoriqueMesures/v1.0
 ITC-GK-R1 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="https://sge-b2b.enedis.fr/services/commandeinformationstechniquesetcontractuelles/v1" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandeinformationstechniquesetcontractuelles/v1">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:demandePublicationITC>
+      <ns0:Body>
+        <ns1:demandePublicationITC>
           <donneesGenerales>
             <initiateurLogin>test@example.com</initiateurLogin>
             <contratId>1234</contratId>
@@ -2531,8 +2531,8 @@ ITC-GK-R1 (C2-C4):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns0:demandePublicationITC>
-      </ns1:Body>
+        </ns1:demandePublicationITC>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeInformationsTechniquesEtContractuelles/v1.0
 ITC-GK-R1 (C2-C4) \*:
@@ -2563,10 +2563,10 @@ ITC-GK-R1 (C2-C4) \*:
   url: https://sge-homologation-ws.enedis.fr/CommandeInformationsTechniquesEtContractuelles/v1.0
 ITC-GK-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="https://sge-b2b.enedis.fr/services/commandeinformationstechniquesetcontractuelles/v1" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandeinformationstechniquesetcontractuelles/v1">
       <SOAP-ENV:Header/>
-      <ns1:Body>
-        <ns0:demandePublicationITC>
+      <ns0:Body>
+        <ns1:demandePublicationITC>
           <donneesGenerales>
             <initiateurLogin>test@example.com</initiateurLogin>
             <contratId>1234</contratId>
@@ -2583,8 +2583,8 @@ ITC-GK-R1 (C5):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns0:demandePublicationITC>
-      </ns1:Body>
+        </ns1:demandePublicationITC>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeInformationsTechniquesEtContractuelles/v1.0
 ITC-GK-R1 (C5) \*:
@@ -2615,10 +2615,10 @@ ITC-GK-R1 (C5) \*:
   url: https://sge-homologation-ws.enedis.fr/CommandeInformationsTechniquesEtContractuelles/v1.0
 MFA-GK-NR1 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
       <SOAP-ENV:Header/>
-      <ns0:Body>
-        <ns1:demandePublicationMesuresFacturantes>
+      <ns1:Body>
+        <ns0:demandePublicationMesuresFacturantes>
           <donneesGenerales>
             <initiateurLogin>test@example.com</initiateurLogin>
             <contratId>1234</contratId>
@@ -2637,8 +2637,8 @@ MFA-GK-NR1 (C2-C4):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns1:demandePublicationMesuresFacturantes>
-      </ns0:Body>
+        </ns0:demandePublicationMesuresFacturantes>
+      </ns1:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeHistoriqueDonneesMesuresFacturantes/v1.0
 MFA-GK-NR1 (C2-C4) \*:
@@ -2671,10 +2671,10 @@ MFA-GK-NR1 (C2-C4) \*:
   url: https://sge-homologation-ws.enedis.fr/CommandeHistoriqueDonneesMesuresFacturantes/v1.0
 MFA-GK-NR1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
       <SOAP-ENV:Header/>
-      <ns0:Body>
-        <ns1:demandePublicationMesuresFacturantes>
+      <ns1:Body>
+        <ns0:demandePublicationMesuresFacturantes>
           <donneesGenerales>
             <initiateurLogin>test@example.com</initiateurLogin>
             <contratId>1234</contratId>
@@ -2693,8 +2693,8 @@ MFA-GK-NR1 (C5):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns1:demandePublicationMesuresFacturantes>
-      </ns0:Body>
+        </ns0:demandePublicationMesuresFacturantes>
+      </ns1:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeHistoriqueDonneesMesuresFacturantes/v1.0
 MFA-GK-NR1 (C5) \*:
@@ -2727,10 +2727,10 @@ MFA-GK-NR1 (C5) \*:
   url: https://sge-homologation-ws.enedis.fr/CommandeHistoriqueDonneesMesuresFacturantes/v1.0
 MFA-GK-R1 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
       <SOAP-ENV:Header/>
-      <ns0:Body>
-        <ns1:demandePublicationMesuresFacturantes>
+      <ns1:Body>
+        <ns0:demandePublicationMesuresFacturantes>
           <donneesGenerales>
             <initiateurLogin>test@example.com</initiateurLogin>
             <contratId>1234</contratId>
@@ -2749,8 +2749,8 @@ MFA-GK-R1 (C2-C4):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns1:demandePublicationMesuresFacturantes>
-      </ns0:Body>
+        </ns0:demandePublicationMesuresFacturantes>
+      </ns1:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeHistoriqueDonneesMesuresFacturantes/v1.0
 MFA-GK-R1 (C2-C4) \*:
@@ -2783,10 +2783,10 @@ MFA-GK-R1 (C2-C4) \*:
   url: https://sge-homologation-ws.enedis.fr/CommandeHistoriqueDonneesMesuresFacturantes/v1.0
 MFA-GK-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="https://sge-b2b.enedis.fr/services/commandehistoriquedonneesmesuresfacturantes/v1" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
       <SOAP-ENV:Header/>
-      <ns0:Body>
-        <ns1:demandePublicationMesuresFacturantes>
+      <ns1:Body>
+        <ns0:demandePublicationMesuresFacturantes>
           <donneesGenerales>
             <initiateurLogin>test@example.com</initiateurLogin>
             <contratId>1234</contratId>
@@ -2805,8 +2805,8 @@ MFA-GK-R1 (C5):
             <sens>SOUTIRAGE</sens>
             <cadreAcces>ACCORD_CLIENT</cadreAcces>
           </demande>
-        </ns1:demandePublicationMesuresFacturantes>
-      </ns0:Body>
+        </ns0:demandePublicationMesuresFacturantes>
+      </ns1:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeHistoriqueDonneesMesuresFacturantes/v1.0
 MFA-GK-R1 (C5) \*:
@@ -3501,7 +3501,7 @@ MFI-GK-R4 (C5) \*:
   url: https://sge-homologation-ws.enedis.fr/CommandeHistoriqueDonneesMesuresFines/v1.0
 MOSAD-R1 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderModificationOptionsServicesAccesDonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderModificationOptionsServicesAccesDonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -3510,8 +3510,8 @@ MOSAD-R1 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderModificationOptionsServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderModificationOptionsServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>98800003605600</pointId>
@@ -3531,13 +3531,13 @@ MOSAD-R1 (C2-C4):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderModificationOptionsServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderModificationOptionsServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeModificationOptionsServicesAccesDonnees/v1.0
 MOSAD-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderModificationOptionsServicesAccesDonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderModificationOptionsServicesAccesDonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -3546,8 +3546,8 @@ MOSAD-R1 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderModificationOptionsServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderModificationOptionsServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>24377424002398</pointId>
@@ -3567,13 +3567,13 @@ MOSAD-R1 (C5):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderModificationOptionsServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderModificationOptionsServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeModificationOptionsServicesAccesDonnees/v1.0
 MOSAD-R2 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderModificationOptionsServicesAccesDonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderModificationOptionsServicesAccesDonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -3582,8 +3582,8 @@ MOSAD-R2 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderModificationOptionsServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderModificationOptionsServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>98800003605600</pointId>
@@ -3603,13 +3603,13 @@ MOSAD-R2 (C2-C4):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderModificationOptionsServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderModificationOptionsServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeModificationOptionsServicesAccesDonnees/v1.0
 MOSAD-R2 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderModificationOptionsServicesAccesDonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderModificationOptionsServicesAccesDonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -3618,8 +3618,8 @@ MOSAD-R2 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderModificationOptionsServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderModificationOptionsServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>24377424002398</pointId>
@@ -3639,13 +3639,13 @@ MOSAD-R2 (C5):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderModificationOptionsServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderModificationOptionsServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeModificationOptionsServicesAccesDonnees/v1.0
 RP-NR1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>2.0</version>
@@ -3654,8 +3654,8 @@ RP-NR1:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherPoint>
+      <ns0:Body>
+        <ns1:rechercherPoint>
           <criteres>
             <adresseInstallation>
               <codePostal>84160</codePostal>
@@ -3665,13 +3665,13 @@ RP-NR1:
             <rechercheHorsPerimetre>false</rechercheHorsPerimetre>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherPoint>
-      </ns1:Body>
+        </ns1:rechercherPoint>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/RecherchePoint/v2.0
 RP-NR2:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>2.0</version>
@@ -3680,8 +3680,8 @@ RP-NR2:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherPoint>
+      <ns0:Body>
+        <ns1:rechercherPoint>
           <criteres>
             <adresseInstallation>
               <numeroEtNomVoie>1 RUE DE LA MER</numeroEtNomVoie>
@@ -3690,13 +3690,13 @@ RP-NR2:
             <rechercheHorsPerimetre>false</rechercheHorsPerimetre>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherPoint>
-      </ns1:Body>
+        </ns1:rechercherPoint>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/RecherchePoint/v2.0
 RP-R1:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>2.0</version>
@@ -3705,8 +3705,8 @@ RP-R1:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherPoint>
+      <ns0:Body>
+        <ns1:rechercherPoint>
           <criteres>
             <adresseInstallation>
               <codePostal>34650</codePostal>
@@ -3717,13 +3717,13 @@ RP-R1:
             <rechercheHorsPerimetre>false</rechercheHorsPerimetre>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherPoint>
-      </ns1:Body>
+        </ns1:rechercherPoint>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/RecherchePoint/v2.0
 RP-R2:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>2.0</version>
@@ -3732,8 +3732,8 @@ RP-R2:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherPoint>
+      <ns0:Body>
+        <ns1:rechercherPoint>
           <criteres>
             <adresseInstallation>
               <numeroEtNomVoie>1 RUE DE LA MER</numeroEtNomVoie>
@@ -3744,8 +3744,8 @@ RP-R2:
             <rechercheHorsPerimetre>true</rechercheHorsPerimetre>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherPoint>
-      </ns1:Body>
+        </ns1:rechercherPoint>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/RecherchePoint/v2.0
 RP-R2 \*:
@@ -3777,7 +3777,7 @@ RP-R2 \*:
   url: https://sge-homologation-ws.enedis.fr/RecherchePoint/v2.0
 RP-R3:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/services/rechercherpoint/v2.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>2.0</version>
@@ -3786,8 +3786,8 @@ RP-R3:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:rechercherPoint>
+      <ns0:Body>
+        <ns1:rechercherPoint>
           <criteres>
             <adresseInstallation>
               <numeroEtNomVoie>1 RUE DE LA MER</numeroEtNomVoie>
@@ -3798,8 +3798,8 @@ RP-R3:
             <rechercheHorsPerimetre>true</rechercheHorsPerimetre>
           </criteres>
           <loginUtilisateur>test@example.com</loginUtilisateur>
-        </ns0:rechercherPoint>
-      </ns1:Body>
+        </ns1:rechercherPoint>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/RecherchePoint/v2.0
 RP-R3 \*:
@@ -3919,7 +3919,7 @@ RSA-R1 (C5):
   url: https://sge-homologation-ws.enedis.fr/RechercheServicesAccesDonnees/v1.0
 RSAD-NR1 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderRenouvellementServicesAccesDonnees/v1.0">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderRenouvellementServicesAccesDonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -3954,7 +3954,7 @@ RSAD-NR1 (C2-C4):
   url: https://sge-homologation-ws.enedis.fr/CommandeRenouvellementServicesAccesDonnees/v1.0
 RSAD-NR1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderRenouvellementServicesAccesDonnees/v1.0">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderRenouvellementServicesAccesDonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -3989,7 +3989,7 @@ RSAD-NR1 (C5):
   url: https://sge-homologation-ws.enedis.fr/CommandeRenouvellementServicesAccesDonnees/v1.0
 RSAD-R1 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderRenouvellementServicesAccesDonnees/v1.0">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderRenouvellementServicesAccesDonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4024,7 +4024,7 @@ RSAD-R1 (C2-C4):
   url: https://sge-homologation-ws.enedis.fr/CommandeRenouvellementServicesAccesDonnees/v1.0
 RSAD-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/b2b/commanderRenouvellementServicesAccesDonnees/v1.0">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderRenouvellementServicesAccesDonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4059,7 +4059,7 @@ RSAD-R1 (C5):
   url: https://sge-homologation-ws.enedis.fr/CommandeRenouvellementServicesAccesDonnees/v1.0
 SAD-NR1 (C2-C4:
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4068,8 +4068,8 @@ SAD-NR1 (C2-C4:
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>98800003605600</pointId>
@@ -4090,13 +4090,13 @@ SAD-NR1 (C2-C4:
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeServicesAccesDonnees/v1.0
 SAD-NR1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4105,8 +4105,8 @@ SAD-NR1 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>25855571545617</pointId>
@@ -4127,13 +4127,13 @@ SAD-NR1 (C5):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeServicesAccesDonnees/v1.0
 SAD-NR2 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4142,8 +4142,8 @@ SAD-NR2 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>98800003605600</pointId>
@@ -4164,13 +4164,13 @@ SAD-NR2 (C2-C4):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeServicesAccesDonnees/v1.0
 SAD-NR2 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4179,8 +4179,8 @@ SAD-NR2 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>25855571545617</pointId>
@@ -4201,13 +4201,13 @@ SAD-NR2 (C5):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeServicesAccesDonnees/v1.0
 SAD-R1 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4216,8 +4216,8 @@ SAD-R1 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>98800003605600</pointId>
@@ -4238,13 +4238,13 @@ SAD-R1 (C2-C4):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeServicesAccesDonnees/v1.0
 SAD-R1 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4253,8 +4253,8 @@ SAD-R1 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>25855571545617</pointId>
@@ -4275,13 +4275,13 @@ SAD-R1 (C5):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeServicesAccesDonnees/v1.0
 SAD-R2 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4290,8 +4290,8 @@ SAD-R2 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>98800003605600</pointId>
@@ -4318,13 +4318,13 @@ SAD-R2 (C2-C4):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeServicesAccesDonnees/v1.0
 SAD-R2 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4333,8 +4333,8 @@ SAD-R2 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>24377424002398</pointId>
@@ -4361,13 +4361,13 @@ SAD-R2 (C5):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeServicesAccesDonnees/v1.0
 SAD-R3 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4376,8 +4376,8 @@ SAD-R3 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>98800003605600</pointId>
@@ -4403,13 +4403,13 @@ SAD-R3 (C2-C4):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeServicesAccesDonnees/v1.0
 SAD-R3 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4418,8 +4418,8 @@ SAD-R3 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>24380318190106</pointId>
@@ -4445,13 +4445,13 @@ SAD-R3 (C5):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeServicesAccesDonnees/v1.0
 SAD-R4 (C2-C4):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4460,8 +4460,8 @@ SAD-R4 (C2-C4):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>98800003605600</pointId>
@@ -4496,13 +4496,13 @@ SAD-R4 (C2-C4):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeServicesAccesDonnees/v1.0
 SAD-R4 (C5):
   data: |
-    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://www.enedis.fr/sge/b2b/commanderservicesaccesdonnees/v1.0" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tec="http://www.enedis.fr/sge/b2b/technique/v1.0" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.enedis.fr/sge/ws/commanderservicesaccesdonnees/v1.0">
       <SOAP-ENV:Header>
         <tec:entete>
           <version>1.0</version>
@@ -4511,8 +4511,8 @@ SAD-R4 (C5):
           </infoDemandeur>
         </tec:entete>
       </SOAP-ENV:Header>
-      <ns1:Body>
-        <ns0:commanderServicesAccesDonnees>
+      <ns0:Body>
+        <ns1:commanderServicesAccesDonnees>
           <demande>
             <donneesGenerales>
               <pointId>25852098337945</pointId>
@@ -4547,7 +4547,7 @@ SAD-R4 (C5):
               </serviceSouscrit>
             </servicesSouscrits>
           </demande>
-        </ns0:commanderServicesAccesDonnees>
-      </ns1:Body>
+        </ns1:commanderServicesAccesDonnees>
+      </ns0:Body>
     </SOAP-ENV:Envelope>
   url: https://sge-homologation-ws.enedis.fr/CommandeServicesAccesDonnees/v1.0


### PR DESCRIPTION
Fetch latest wsdl/xsd files definitions for theses services. This fixes wrong url http://www.enedis.fr/sge/b2b/... that should be http://www.enedis.fr/sge/ws/...

Fix inconsistent location of
ENEDIS.Dictionnaire.{TypeComplexe,TypeSimple}.v5.0.xsd files by using symlinks.

Drop the `ns1:` prefix from `client.factory.create()` calls in the 4 SAD service functions. suds assigns ns* prefixes in alphabetical order of namespaces, and the new `ws/...` target namespace now comes after the b2b/dictionnaire/* ones, so the hardcoded `ns1:` no longer points to the operation namespace.