### PR TITLE
Handle multiple services in cmdModificationOptionsServicesAccesDonnees

### DIFF
--- a/doc/homologation.md
+++ b/doc/homologation.md
@@ -103,12 +103,12 @@ CommandeArretServicesAccesDonnees v1.0
 CommandeModificationOptionsServicesAccesDonnees v1.0
 ----------------------------------------------------
 
-| Case              | Command                                                                                                                            |
-|-------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| MOSAD-R1 (C5)     | `lowatt-enedis cmdModificationOptionsServicesAccesDonnees 24377424002398 --service-id 666 --add-period daily --add-corrigee`    |
-| MOSAD-R1 (C2-C4)  | `lowatt-enedis cmdModificationOptionsServicesAccesDonnees 98800003605600 --service-id 666 --add-period daily --add-corrigee`    |
-| MOSAD-R2 (C5)     | `lowatt-enedis cmdModificationOptionsServicesAccesDonnees 24377424002398 --service-id 666 --drop-period daily --drop-corrigee`  |
-| MOSAD-R2 (C2-C4)  | `lowatt-enedis cmdModificationOptionsServicesAccesDonnees 98800003605600 --service-id 666 --drop-period daily --drop-corrigee`  |
+| Case              | Command                                                                                          |
+|-------------------|--------------------------------------------------------------------------------------------------|
+| MOSAD-R1 (C5)     | `lowatt-enedis cmdModificationOptionsServicesAccesDonnees 24377424002398 --add 666:daily:true`   |
+| MOSAD-R1 (C2-C4)  | `lowatt-enedis cmdModificationOptionsServicesAccesDonnees 98800003605600 --add 666:daily:true`   |
+| MOSAD-R2 (C5)     | `lowatt-enedis cmdModificationOptionsServicesAccesDonnees 24377424002398 --drop 666:daily:true`  |
+| MOSAD-R2 (C2-C4)  | `lowatt-enedis cmdModificationOptionsServicesAccesDonnees 98800003605600 --drop 666:daily:true`  |
 
 CommandeRenouvellementServicesAccesDonnees v1.0
 -----------------------------------------------

--- a/lowatt_enedis/services.py
+++ b/lowatt_enedis/services.py
@@ -22,10 +22,18 @@ SGE web-service mapping to plug them into the CLI.
 """
 
 import argparse
+import dataclasses
+import sys
+import typing
 import warnings
 from collections.abc import Iterator
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Literal
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 import suds.sudsobject
 from suds.client import Client
@@ -1259,31 +1267,51 @@ def point_cmd_arret_service_acces_donnees(
     return client.service.commanderArretServicesAccesDonnees(demande)
 
 
+Period = Literal["daily", "weekly", "monthly"]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class OptionPublication:
+    service_id: str
+    period: Period
+    corrigee: bool
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        service_id, period, corrigee = value.split(":")
+        assert corrigee in ("true", "false"), corrigee
+        period = typing.cast(Period, period)
+        assert period in typing.get_args(Period), period
+        return cls(service_id, period, corrigee == "true")
+
+
 @register(
     "cmdModificationOptionsServicesAccesDonnees",
     "CommanderModificationOptionsServicesAccesDonnees-V1.0",
     DONNEES_GENERALES_OPTIONS
     | SENS_OPTIONS
     | {
-        "--service-id": {
-            "help": "identifiant du service a modifier",
-            "required": True,
+        "--add": {
+            "dest": "add",
+            "action": "append",
+            "type": OptionPublication.parse,
+            "metavar": "SERVICE_ID:PERIOD:CORRIGEE",
+            "help": (
+                "Option de publication à ajouter (peut être répété). "
+                "PERIOD: daily|weekly|monthly. "
+                "CORRIGEE: true|false"
+            ),
         },
-        "--add-corrigee": {
-            "action": "store_true",
-            "help": "ajouter l'option mesures corrigées",
-        },
-        "--add-period": {
-            "choices": list(PERIODS),
-            "help": "ajouter la publication",
-        },
-        "--drop-corrigee": {
-            "action": "store_true",
-            "help": "supprimer l'option mesures corrigées",
-        },
-        "--drop-period": {
-            "choices": list(PERIODS),
-            "help": "supprimer la publication",
+        "--drop": {
+            "dest": "drop",
+            "action": "append",
+            "type": OptionPublication.parse,
+            "metavar": "SERVICE_ID:PERIOD:CORRIGEE",
+            "help": (
+                "Option de publication à supprimer (peut être répété). "
+                "PERIOD: daily|weekly|monthly. "
+                "CORRIGEE: true|false."
+            ),
         },
     },
 )
@@ -1291,8 +1319,6 @@ def point_cmd_arret_service_acces_donnees(
 def point_modify_options_acces_donnees(
     client: Client, args: argparse.Namespace
 ) -> suds.sudsobject.Object:
-    service_id = get_option(args, "service_id")
-
     demande = client.factory.create("DemandeType")
     demande.donneesGenerales = create_from_options(
         client,
@@ -1306,24 +1332,36 @@ def point_modify_options_acces_donnees(
     demande.donneesGenerales.contratId = get_option(args, "contrat")
     demande.donneesGenerales.sens = get_option(args, "sens")
     demande.servicesSouscrits = client.factory.create("ServicesSouscritsType")
-    service = client.factory.create("ServiceSouscritType")
-    service.serviceSouscritId = service_id
-    demande.servicesSouscrits.serviceSouscrit = [service]
+    demande.servicesSouscrits.serviceSouscrit = []
 
-    for prefix in ("add", "drop"):
-        svc = client.factory.create("OptionsPublicationType")
-        if period := get_option(args, f"{prefix}_period"):
-            opt = client.factory.create("OptionPublicationType")
-            opt.periodiciteTransmission = PERIODS[period]
-            if get_option(args, f"{prefix}_corrigee"):
-                opt.mesuresCorrigees = _boolean(True)
-            else:
-                opt.mesuresCorrigees = _boolean(False)
-            svc.optionPublication = [opt]
-            if prefix == "add":
-                service.ajouterOptionsPublication = [svc]
-            else:
-                service.supprimerOptionsPublication = [svc]
+    by_service: dict[str, dict[str, list[OptionPublication]]] = {}
+    for action in ("add", "drop"):
+        for svc in get_option(args, action) or []:
+            by_service.setdefault(svc.service_id, {"add": [], "drop": []})[
+                action
+            ].append(svc)
+
+    if not by_service:
+        raise ValueError("Au moins une des options --add ou --drop doit être donnée.")
+
+    for service_id in by_service:
+        service = client.factory.create("ServiceSouscritType")
+        service.serviceSouscritId = service_id
+        demande.servicesSouscrits.serviceSouscrit.append(service)
+        for action in ("add", "drop"):
+            pubs = []
+            for svc in by_service[service_id][action]:
+                pub = client.factory.create("OptionsPublicationType")
+                opt = client.factory.create("OptionPublicationType")
+                opt.periodiciteTransmission = PERIODS[svc.period]
+                opt.mesuresCorrigees = _boolean(svc.corrigee)
+                pub.optionPublication = [opt]
+                pubs.append(pub)
+            if pubs:
+                if action == "add":
+                    service.ajouterOptionsPublication = pubs
+                else:
+                    service.supprimerOptionsPublication = pubs
 
     return client.service.commanderModificationOptionsServicesAccesDonnees(demande)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "certifi",
     "suds-py3",
     "rich",
+    "typing_extensions; python_version < '3.11'",
 ]
 
 [project.urls]

--- a/test/data/expected-cli-output.yml
+++ b/test/data/expected-cli-output.yml
@@ -197,7 +197,7 @@ lowatt-enedis cmdInfraJ --help: |
     --homologation        Change service host to use homologation sandbox. Enabled by presence of ENEDIS_HOMOLOGATION in environment variables.
     --output {xml,json}   Output type. Default is xml
 lowatt-enedis cmdModificationOptionsServicesAccesDonnees --help: |
-  usage: lowatt-enedis cmdModificationOptionsServicesAccesDonnees [-h] --login LOGIN --contrat CONTRAT [--sens {SOUTIRAGE,INJECTION}] --service-id SERVICE_ID [--add-corrigee] [--add-period {daily,weekly,monthly}] [--drop-corrigee] [--drop-period {daily,weekly,monthly}] --cert-file CERT_FILE --key-file KEY_FILE [--homologation] [--output {xml,json}] prm
+  usage: lowatt-enedis cmdModificationOptionsServicesAccesDonnees [-h] --login LOGIN --contrat CONTRAT [--sens {SOUTIRAGE,INJECTION}] [--add SERVICE_ID:PERIOD:CORRIGEE] [--drop SERVICE_ID:PERIOD:CORRIGEE] --cert-file CERT_FILE --key-file KEY_FILE [--homologation] [--output {xml,json}] prm
 
   positional arguments:
     prm                   identifiant PRM du point
@@ -208,14 +208,10 @@ lowatt-enedis cmdModificationOptionsServicesAccesDonnees --help: |
     --contrat CONTRAT     identifiant du contrat entre le demandeur et Enedis. Default to ENEDIS_CONTRAT environment variable.
     --sens {SOUTIRAGE,INJECTION}
                           Sens de l'énergie circulant vers le réseau d'Enedis. SOUTIRAGE par défaut.
-    --service-id SERVICE_ID
-                          identifiant du service a modifier
-    --add-corrigee        ajouter l'option mesures corrigées
-    --add-period {daily,weekly,monthly}
-                          ajouter la publication
-    --drop-corrigee       supprimer l'option mesures corrigées
-    --drop-period {daily,weekly,monthly}
-                          supprimer la publication
+    --add SERVICE_ID:PERIOD:CORRIGEE
+                          Option de publication à ajouter (peut être répété). PERIOD: daily|weekly|monthly. CORRIGEE: true|false
+    --drop SERVICE_ID:PERIOD:CORRIGEE
+                          Option de publication à supprimer (peut être répété). PERIOD: daily|weekly|monthly. CORRIGEE: true|false.
     --cert-file CERT_FILE
                           Client certificate file. Default to ENEDIS_CERT_FILE environment variable.
     --key-file KEY_FILE   Client private key file. Default to ENEDIS_KEY_FILE environment variable.


### PR DESCRIPTION
cmdModificationOptionsServicesAccesDonnees can handle multiple option publication addings and removals in a single call.

Handle this in CLI by using --add/--drop command with option publication described as SERVICE_ID:PERIOD:CORRIGEE.