### PR TITLE
Fix point_cmd_acces_donnees() with ENERGIE and publication

### DIFF
--- a/lowatt_enedis/services.py
+++ b/lowatt_enedis/services.py
@@ -1202,7 +1202,8 @@ def point_cmd_acces_donnees(
         service = client.factory.create("ServiceSouscritType")
         service.typeDonnees = type_donnees
 
-        if period:
+        # Les options de publication ne sont pas disponibles pour le type de donnée ENERGIE.
+        if type_donnees != "ENERGIE" and period:
             pub = client.factory.create("OptionsPublicationType")
             option = client.factory.create("OptionPublicationType")
             option.periodiciteTransmission = PERIODS[period]


### PR DESCRIPTION
We can't add a OptionsPublicationType on ENERGIE data type, it raise an error:

SGT4T2: Demande non recevable : Les options de publication ne sont pas disponibles pour le type de donnée ENERGIE.

Handle this in point_cmd_acces_donnees() by skipping OptionsPublicationType for ENERGIE type, so publication only apply to other types in same call.